### PR TITLE
All possible filter combinations applied to data counts

### DIFF
--- a/Initial Molecule Choices/README.md
+++ b/Initial Molecule Choices/README.md
@@ -1,17 +1,20 @@
 # open-forcefield-data/Initial Molecule Choices
 Organized csv files showing data point count statistics of molecules and mixtures across all pure solvent and binary mixture properties
 
-# csv contents 
+# MAIN csv contents ('_all' title appendage) 
 
-allcomp_counts_all.csv - counts of number of data points for all molecules appearing in the pure and binary mixture sets across all properties
+allcomp_counts_all.csv - counts of number of data points for all molecules appearing in the pure and binary mixture sets across all properties (no additional filters applied)
 
-allcomp_counts_diverse.csv - analogous to allcomp_counts_all.csv, but only for molecules which appeared on Chris's diverse set
+bincomp_counts_all.csv - Count of data points per unique molecule across all binary properties. It’s important to note that while this count was performed on individual components, it is for the binary property sets (no additional filters applied)
 
-bincomp_counts_all.csv - Count of data points per unique molecule across all binary properties. It’s important to note that while this count was performed on individual components, it is for the binary property sets.
+mix_counts_all.csv - count of the number of data points per unique binary mixture across all mixture properties (no additional filters applied)
 
-mix_counts_all.csv - count of the number of data points per unique binary mixture across all mixture properties
+purecomp_counts_all.csv - Count of data points per unique molecule across all pure properties (no additional filters applied)
 
-mix_counts_interesting.csv - analogous to mix_counts_all.csv, but eliminates all alkane-alkane mixtures (also prefiltered to eliminate mixtures containing molecules not on Chris's diverse list)
+# Additional title appendange meanings
 
-purecomp_counts_all.csv - Count of data points per unique molecule across all pure properties
+_diverse - These data point counts represent only molecules on Chris's diverse list (see: https://github.com/open-forcefield-group/open-forcefield-data/blob/master/Model-Systems/AlkEthOH_distrib/AlkEthOH_chain_filt1.smi and https://github.com/open-forcefield-group/open-forcefield-data/blob/master/Model-Systems/AlkEthOH_distrib/AlkEthOH_rings_filt1.smi) 
 
+_interesting - These data point counts contain only binary data for those mixtures which are not alkane-alkane
+
+**Both appendages would mean both filters were applied

--- a/Initial Molecule Choices/README.md
+++ b/Initial Molecule Choices/README.md
@@ -1,6 +1,10 @@
 # open-forcefield-data/Initial Molecule Choices
 Organized csv files showing data point count statistics of molecules and mixtures across all pure solvent and binary mixture properties
 
+All files with '_all' or lone '_interesting' title appendage were created using the thermomlcnts.py script in the 'Python' directory (https://github.com/open-forcefield-group/open-forcefield-data/tree/master/Python)
+
+Any files with the '_diverse' title appendage (or any combination of it) was created using the diversitychk.py script in the 'Python' directory (https://github.com/open-forcefield-group/open-forcefield-data/tree/master/Python)
+
 # MAIN csv contents ('_all' title appendage) 
 
 allcomp_counts_all.csv - counts of number of data points for all molecules appearing in the pure and binary mixture sets across all properties (no additional filters applied)

--- a/Initial Molecule Choices/allcomp_counts_diverse.csv
+++ b/Initial Molecule Choices/allcomp_counts_diverse.csv
@@ -1,77 +1,77 @@
-,Unnamed: 0,Component,SMILES,Component Count dens pure,Component Count cpmol pure,Component Count sos pure,Component Count dielec pure,Component Count hmol pure,Component Count vmol pure,Component Count vspec pure,Component Count dens binary,Component Count actcoeff binary,Component Count sos binary,Component Count dielec binary,Component Count eme binary,Component Count emcp binary,Component Count emv binary,Component Count all 
-8,8,water,O,634,54,183,31,0,0,39,10916,122,964,34,376,390,578,14321
-3,3,ethanol,CCO,1169,86,91,8,0,0,2,4585,11,408,105,507,0,23,6995
-1,1,1-butanol,CCCCO,1327,49,85,11,0,0,0,2773,8,897,105,581,130,71,6037
-2,2,heptane,CCCCCCC,1254,39,132,3,12,1,0,3328,8,560,64,202,0,14,5617
-11,11,cyclohexane,C1CCCCC1,368,21,55,0,0,11,0,2548,7,520,0,336,0,14,3880
-6,6,1-propanol,CCCO,659,18,78,7,0,0,0,2428,6,430,0,118,0,0,3744
-12,12,2-propanol,CC(C)O,357,6,53,5,0,0,0,2433,6,418,105,139,0,0,3522
-9,9,methanol,CO,606,75,142,7,0,0,0,853,5,31,515,210,0,0,2444
-25,25,methylcyclohexane,CC1CCCCC1,142,0,8,0,0,0,0,1478,1,354,0,76,0,0,2059
-64,64,tert-butyl ethyl ether,CCOC(C)(C)C,32,0,24,0,0,0,0,1048,4,819,0,0,0,0,1927
-57,57,"2,2,4-trimethylpentane",CC(C)CC(C)(C)C,45,0,12,0,0,0,0,1370,0,261,0,156,0,0,1844
-5,5,1-hexanol,CCCCCCO,664,8,64,2,0,0,0,729,0,204,0,31,0,0,1702
-10,10,1-pentanol,CCCCCO,396,0,78,10,0,0,0,670,0,89,90,299,0,0,1632
-20,20,hexane,CCCCCC,196,0,93,0,0,0,0,651,14,223,0,157,0,87,1421
-4,4,2-methyl-1-propanol,CC(C)CO,721,0,15,5,0,0,0,399,0,71,105,31,0,0,1347
-50,50,2-methyl-2-propanol,CC(C)(C)O,65,0,16,0,0,0,0,1168,0,45,0,0,0,0,1294
-61,61,2-methyl-2-butanol,CCC(C)(C)O,37,88,43,0,0,0,0,248,16,450,0,98,0,39,1019
-62,62,tetrahydropyran,C1CCOCC1,35,11,19,0,0,0,0,289,0,254,0,218,0,112,938
-73,73,cyclopentane,C1CCCC1,18,0,15,0,0,0,0,412,6,398,0,63,0,0,912
-63,63,2-methoxyethanol,COCCO,35,0,10,0,0,0,0,517,17,306,0,0,0,0,885
-41,41,tetrahydrofuran,C1CCOC1,96,0,43,0,0,1,0,457,0,116,0,98,0,39,850
-47,47,"1,4-dioxane",C1COCCO1,77,0,32,3,0,0,0,241,0,243,0,47,0,0,643
-167,167,n-propyl alcohol,CCCO,0,0,0,0,0,0,0,357,0,66,105,84,0,0,612
-166,166,isooctane,CCCCCC(C)C,0,0,0,0,0,0,0,413,0,72,0,42,0,0,527
-49,49,butan-2-ol,CCC(C)O,75,0,13,0,0,0,0,202,0,136,0,85,0,0,511
-78,78,pentane,CCCCC,15,0,0,0,0,0,0,483,6,0,0,0,0,0,504
-173,173,tert-butanol,CC(C)(C)O,0,0,0,0,0,0,0,267,0,132,95,0,0,0,494
-85,85,1-propoxy-2-propanol,CCCOCC(C)O,10,0,10,0,0,0,0,318,0,145,0,0,0,0,483
-168,168,amylcarbinol,CCCCCCO,0,0,0,0,0,0,0,344,0,96,0,19,0,0,459
-81,81,cyclooctane,C1CCCCCCC1,12,0,4,0,0,0,0,271,7,144,0,0,0,0,438
-33,33,methoxymethane,COC,108,81,0,145,0,0,0,0,23,0,0,76,0,0,433
-80,80,"1,3-dioxolane",C1COCO1,13,0,11,0,0,0,0,204,0,148,0,0,0,0,376
-84,84,2-methyl-1-butanol,CCC(C)CO,11,73,43,0,0,0,0,173,15,56,0,0,0,0,371
-56,56,isopropyl ether,CC(C)OC(C)C,47,0,22,0,0,0,0,88,0,97,0,101,0,0,355
-60,60,3-methyl-1-butanol,CC(C)CCO,37,0,4,0,0,0,0,235,15,52,0,0,0,0,343
-67,67,2-pentanol,CCCC(C)O,26,47,6,0,0,0,0,126,13,39,0,84,0,0,341
-188,188,methyl alcohol,CO,0,0,0,0,0,0,0,129,0,0,105,87,0,0,321
-114,114,"ethanol, 2-propoxy-",CCCOCCO,4,0,0,3,0,0,0,151,0,73,78,0,0,0,309
-24,24,2-hexanol,CCCCC(C)O,154,0,2,0,0,0,0,90,0,42,0,0,0,0,288
-143,143,neopentyl alcohol,CC(C)(C)CO,0,61,0,0,5,0,0,213,0,0,0,0,0,0,279
-55,55,butane,CCCC,50,0,0,0,0,0,0,163,21,0,0,0,0,0,234
-66,66,"ethanol, 2-ethoxy-",CCOCCO,28,0,11,0,0,0,0,47,0,27,0,117,0,0,230
-178,178,"2-methyl-1,3-propanediol",CC(CO)CO,0,0,0,0,0,0,0,209,0,0,0,0,0,0,209
-192,192,2-ethoxyethanol,CCOCCO,0,0,0,0,0,0,0,44,0,44,0,104,0,0,192
-182,182,propane,CCC,0,0,0,0,0,0,0,157,21,0,0,0,0,0,178
-187,187,"ether, methyl tert-pentyl",CCC(C)(C)OC,0,0,0,0,0,0,0,136,0,21,0,0,0,19,176
-183,183,"2,2-dimethyl-1,3-propanediol",CC(C)(CO)CO,0,0,0,0,0,0,0,156,0,0,0,0,0,0,156
-87,87,2-methyltetrahydrofuran,CC1CCCO1,10,8,4,0,0,0,0,27,0,45,0,44,0,0,138
-186,186,"3-methylpentane-1,5-diol",CC(CCO)CCO,0,0,0,0,0,0,0,138,0,0,0,0,0,0,138
-27,27,dimethoxymethane,COCOC,119,0,0,0,0,0,0,0,0,0,0,0,0,0,119
-38,38,2-methylpentane,CCCC(C)C,100,0,0,0,0,0,0,0,0,0,0,19,0,0,119
-34,34,2-methylheptane,CCCCCC(C)C,107,10,0,0,0,0,0,0,0,0,0,0,0,0,117
-52,52,diethyl ether,CCOCC,61,0,1,0,0,0,0,22,0,23,0,0,0,0,107
-35,35,"2,3-dimethylbutane",CC(C)C(C)C,101,0,0,0,0,0,0,0,0,0,0,0,0,0,101
-36,36,"2,2-dimethylbutane",CCC(C)(C)C,101,0,0,0,0,0,0,0,0,0,0,0,0,0,101
-37,37,3-methylpentane,CCC(C)CC,100,0,0,0,0,0,0,0,0,0,0,0,0,0,100
-83,83,2-heptanol,CCCCCC(C)O,11,1,2,0,0,0,0,42,0,42,0,0,0,0,98
-191,191,2-(2-methylpropoxy)ethanol,CC(C)COCCO,0,0,0,0,0,0,0,45,0,45,0,0,0,0,90
-54,54,2-methylpropane,CC(C)C,58,0,0,0,0,0,0,0,21,0,0,0,0,0,79
-70,70,ethane,CC,25,0,0,0,0,0,0,44,0,0,0,0,0,0,69
-204,204,diisopropyl,CC(C)C(C)C,0,0,0,0,0,0,0,0,0,0,0,63,0,0,63
-205,205,neohexane,CCC(C)(C)C,0,0,0,0,0,0,0,0,0,0,0,62,0,0,62
-206,206,"ether, dipropyl",CCCOCCC,0,0,0,0,0,0,0,0,0,0,0,59,0,0,59
-145,145,3-methyl-2-butanol,CC(C)C(C)O,0,30,0,0,0,0,0,0,10,0,0,0,0,0,40
-141,141,2-isopropoxyethanol,CC(C)OCCO,1,0,1,0,0,0,0,18,0,18,0,0,0,0,38
-195,195,methane,C,0,0,0,0,0,0,0,37,0,0,0,0,0,0,37
-91,91,dipropyl ether,CCCOCCC,9,0,0,0,0,0,0,0,0,0,0,20,0,0,29
-109,109,propylene glycol monoethyl ether,CCOCC(C)O,5,0,5,0,0,0,0,0,0,0,0,0,0,0,10
-93,93,"ether, ethyl butyl",CCCCOCC,8,0,0,0,0,0,0,0,0,0,0,0,0,0,8
-122,122,tert-amyl methyl ether,CCC(C)(C)OC,3,0,1,0,0,0,0,0,4,0,0,0,0,0,8
-120,120,methylcyclopentane,CC1CCCC1,3,0,3,0,0,0,0,0,1,0,0,0,0,0,7
-202,202,cycloheptane,C1CCCCCC1,0,0,0,0,0,0,0,0,6,0,0,0,0,0,6
-116,116,4-methyl-2-pentanol,CC(C)CC(C)O,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
-117,117,2-methyl-1-pentanol,CCCC(C)CO,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
-118,118,2-methyl-2-pentanol,CCCC(C)(C)O,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
-127,127,"1,1-diethoxyethane",CCOC(C)OCC,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
+,Component,SMILES,Component Count dens pure,Component Count cpmol pure,Component Count sos pure,Component Count dielec pure,Component Count hmol pure,Component Count vmol pure,Component Count vspec pure,Component Count dens binary,Component Count actcoeff binary,Component Count sos binary,Component Count dielec binary,Component Count eme binary,Component Count emcp binary,Component Count emv binary,Component Count all
+0,water,O,634,54,183,31,0,0,39,10916,122,964,34,376,390,578,14321
+2,ethanol,CCO,1169,86,91,8,0,0,2,4585,11,408,105,507,0,23,6995
+3,1-butanol,CCCCO,1327,49,85,11,0,0,0,2773,8,897,105,581,130,71,6037
+4,heptane,CCCCCCC,1254,39,132,3,12,1,0,3328,8,560,64,202,0,14,5617
+7,cyclohexane,C1CCCCC1,368,21,55,0,0,11,0,2548,7,520,0,336,0,14,3880
+8,1-propanol,CCCO,659,18,78,7,0,0,0,2428,6,430,0,118,0,0,3744
+9,2-propanol,CC(C)O,357,6,53,5,0,0,0,2433,6,418,105,139,0,0,3522
+12,methanol,CO,606,75,142,7,0,0,0,853,5,31,515,210,0,0,2444
+16,methylcyclohexane,CC1CCCCC1,142,0,8,0,0,0,0,1478,1,354,0,76,0,0,2059
+18,tert-butyl ethyl ether,CCOC(C)(C)C,32,0,24,0,0,0,0,1048,4,819,0,0,0,0,1927
+19,"2,2,4-trimethylpentane",CC(C)CC(C)(C)C,45,0,12,0,0,0,0,1370,0,261,0,156,0,0,1844
+21,1-hexanol,CCCCCCO,664,8,64,2,0,0,0,729,0,204,0,31,0,0,1702
+22,1-pentanol,CCCCCO,396,0,78,10,0,0,0,670,0,89,90,299,0,0,1632
+23,hexane,CCCCCC,196,0,93,0,0,0,0,651,14,223,0,157,0,87,1421
+26,2-methyl-1-propanol,CC(C)CO,721,0,15,5,0,0,0,399,0,71,105,31,0,0,1347
+30,2-methyl-2-propanol,CC(C)(C)O,65,0,16,0,0,0,0,1168,0,45,0,0,0,0,1294
+33,2-methyl-2-butanol,CCC(C)(C)O,37,88,43,0,0,0,0,248,16,450,0,98,0,39,1019
+36,tetrahydropyran,C1CCOCC1,35,11,19,0,0,0,0,289,0,254,0,218,0,112,938
+38,cyclopentane,C1CCCC1,18,0,15,0,0,0,0,412,6,398,0,63,0,0,912
+39,2-methoxyethanol,COCCO,35,0,10,0,0,0,0,517,17,306,0,0,0,0,885
+42,tetrahydrofuran,C1CCOC1,96,0,43,0,0,1,0,457,0,116,0,98,0,39,850
+46,"1,4-dioxane",C1COCCO1,77,0,32,3,0,0,0,241,0,243,0,47,0,0,643
+47,n-propyl alcohol,CCCO,0,0,0,0,0,0,0,357,0,66,105,84,0,0,612
+51,isooctane,CCCCCC(C)C,0,0,0,0,0,0,0,413,0,72,0,42,0,0,527
+52,butan-2-ol,CCC(C)O,75,0,13,0,0,0,0,202,0,136,0,85,0,0,511
+53,pentane,CCCCC,15,0,0,0,0,0,0,483,6,0,0,0,0,0,504
+54,tert-butanol,CC(C)(C)O,0,0,0,0,0,0,0,267,0,132,95,0,0,0,494
+55,1-propoxy-2-propanol,CCCOCC(C)O,10,0,10,0,0,0,0,318,0,145,0,0,0,0,483
+57,amylcarbinol,CCCCCCO,0,0,0,0,0,0,0,344,0,96,0,19,0,0,459
+58,cyclooctane,C1CCCCCCC1,12,0,4,0,0,0,0,271,7,144,0,0,0,0,438
+59,methoxymethane,COC,108,81,0,145,0,0,0,0,23,0,0,76,0,0,433
+63,"1,3-dioxolane",C1COCO1,13,0,11,0,0,0,0,204,0,148,0,0,0,0,376
+64,2-methyl-1-butanol,CCC(C)CO,11,73,43,0,0,0,0,173,15,56,0,0,0,0,371
+67,isopropyl ether,CC(C)OC(C)C,47,0,22,0,0,0,0,88,0,97,0,101,0,0,355
+68,3-methyl-1-butanol,CC(C)CCO,37,0,4,0,0,0,0,235,15,52,0,0,0,0,343
+69,2-pentanol,CCCC(C)O,26,47,6,0,0,0,0,126,13,39,0,84,0,0,341
+72,methyl alcohol,CO,0,0,0,0,0,0,0,129,0,0,105,87,0,0,321
+74,"ethanol, 2-propoxy-",CCCOCCO,4,0,0,3,0,0,0,151,0,73,78,0,0,0,309
+76,2-hexanol,CCCCC(C)O,154,0,2,0,0,0,0,90,0,42,0,0,0,0,288
+78,neopentyl alcohol,CC(C)(C)CO,0,61,0,0,5,0,0,213,0,0,0,0,0,0,279
+83,butane,CCCC,50,0,0,0,0,0,0,163,21,0,0,0,0,0,234
+85,"ethanol, 2-ethoxy-",CCOCCO,28,0,11,0,0,0,0,47,0,27,0,117,0,0,230
+91,"2-methyl-1,3-propanediol",CC(CO)CO,0,0,0,0,0,0,0,209,0,0,0,0,0,0,209
+95,2-ethoxyethanol,CCOCCO,0,0,0,0,0,0,0,44,0,44,0,104,0,0,192
+97,propane,CCC,0,0,0,0,0,0,0,157,21,0,0,0,0,0,178
+100,"ether, methyl tert-pentyl",CCC(C)(C)OC,0,0,0,0,0,0,0,136,0,21,0,0,0,19,176
+105,"2,2-dimethyl-1,3-propanediol",CC(C)(CO)CO,0,0,0,0,0,0,0,156,0,0,0,0,0,0,156
+107,2-methyltetrahydrofuran,CC1CCCO1,10,8,4,0,0,0,0,27,0,45,0,44,0,0,138
+108,"3-methylpentane-1,5-diol",CC(CCO)CCO,0,0,0,0,0,0,0,138,0,0,0,0,0,0,138
+112,dimethoxymethane,COCOC,119,0,0,0,0,0,0,0,0,0,0,0,0,0,119
+114,2-methylpentane,CCCC(C)C,100,0,0,0,0,0,0,0,0,0,0,19,0,0,119
+115,2-methylheptane,CCCCCC(C)C,107,10,0,0,0,0,0,0,0,0,0,0,0,0,117
+117,diethyl ether,CCOCC,61,0,1,0,0,0,0,22,0,23,0,0,0,0,107
+120,"2,3-dimethylbutane",CC(C)C(C)C,101,0,0,0,0,0,0,0,0,0,0,0,0,0,101
+121,"2,2-dimethylbutane",CCC(C)(C)C,101,0,0,0,0,0,0,0,0,0,0,0,0,0,101
+122,3-methylpentane,CCC(C)CC,100,0,0,0,0,0,0,0,0,0,0,0,0,0,100
+125,2-heptanol,CCCCCC(C)O,11,1,2,0,0,0,0,42,0,42,0,0,0,0,98
+127,2-(2-methylpropoxy)ethanol,CC(C)COCCO,0,0,0,0,0,0,0,45,0,45,0,0,0,0,90
+133,2-methylpropane,CC(C)C,58,0,0,0,0,0,0,0,21,0,0,0,0,0,79
+138,ethane,CC,25,0,0,0,0,0,0,44,0,0,0,0,0,0,69
+141,diisopropyl,CC(C)C(C)C,0,0,0,0,0,0,0,0,0,0,0,63,0,0,63
+143,neohexane,CCC(C)(C)C,0,0,0,0,0,0,0,0,0,0,0,62,0,0,62
+146,"ether, dipropyl",CCCOCCC,0,0,0,0,0,0,0,0,0,0,0,59,0,0,59
+152,3-methyl-2-butanol,CC(C)C(C)O,0,30,0,0,0,0,0,0,10,0,0,0,0,0,40
+155,2-isopropoxyethanol,CC(C)OCCO,1,0,1,0,0,0,0,18,0,18,0,0,0,0,38
+156,methane,C,0,0,0,0,0,0,0,37,0,0,0,0,0,0,37
+159,dipropyl ether,CCCOCCC,9,0,0,0,0,0,0,0,0,0,0,20,0,0,29
+167,propylene glycol monoethyl ether,CCOCC(C)O,5,0,5,0,0,0,0,0,0,0,0,0,0,0,10
+171,"ether, ethyl butyl",CCCCOCC,8,0,0,0,0,0,0,0,0,0,0,0,0,0,8
+174,tert-amyl methyl ether,CCC(C)(C)OC,3,0,1,0,0,0,0,0,4,0,0,0,0,0,8
+175,methylcyclopentane,CC1CCCC1,3,0,3,0,0,0,0,0,1,0,0,0,0,0,7
+179,cycloheptane,C1CCCCCC1,0,0,0,0,0,0,0,0,6,0,0,0,0,0,6
+186,4-methyl-2-pentanol,CC(C)CC(C)O,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
+187,2-methyl-1-pentanol,CCCC(C)CO,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
+188,2-methyl-2-pentanol,CCCC(C)(C)O,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
+192,"1,1-diethoxyethane",CCOC(C)OCC,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3

--- a/Initial Molecule Choices/allcomp_counts_interesting.csv
+++ b/Initial Molecule Choices/allcomp_counts_interesting.csv
@@ -1,0 +1,209 @@
+,Component,SMILES,Component Count dens pure,Component Count cpmol pure,Component Count sos pure,Component Count dielec pure,Component Count hmol pure,Component Count vmol pure,Component Count vspec pure,Component Count dens binary,Component Count actcoeff binary,Component Count sos binary,Component Count dielec binary,Component Count eme binary,Component Count emcp binary,Component Count emv binary,Component Count all
+8,water,O,634,54,183,31,0,0,39,10916,122,964,34,376,390,578,14321
+0,decane,CCCCCCCCCC,9289,8,21,0,0,0,0,352,6,145,0,60,0,0,9881
+3,ethanol,CCO,1169,86,91,8,0,0,2,4585,11,408,105,507,0,23,6995
+1,1-butanol,CCCCO,1327,49,85,11,0,0,0,2773,8,897,105,581,130,71,6037
+7,toluene,Cc1ccccc1,641,3,235,51,0,0,0,2663,29,660,0,158,0,14,4454
+2,heptane,CCCCCCC,1254,39,132,3,12,1,0,2147,8,560,64,202,0,14,4436
+6,1-propanol,CCCO,659,18,78,7,0,0,0,2428,6,430,0,118,0,0,3744
+12,2-propanol,CC(C)O,357,6,53,5,0,0,0,2433,6,418,105,139,0,0,3522
+53,methyl tert-butyl ether,COC(C)(C)C,59,0,33,0,0,0,0,2321,4,838,0,140,0,0,3395
+19,benzene,c1ccccc1,251,6,45,0,0,0,1,2314,24,393,0,229,0,14,3277
+14,octane,CCCCCCCC,317,11,16,8,0,0,0,2022,13,226,90,94,0,0,2797
+11,cyclohexane,C1CCCCC1,368,21,55,0,0,11,0,1465,7,520,0,302,0,14,2763
+9,methanol,CO,606,75,142,7,0,0,0,853,5,31,515,210,0,0,2444
+42,dibutyl ether,CCCCOCCCC,83,0,6,5,0,0,0,1271,0,349,90,576,0,0,2380
+29,"1,4-dimethylbenzene",Cc1ccc(C)cc1,116,3,43,0,0,0,0,1259,22,600,0,14,0,14,2071
+25,methylcyclohexane,CC1CCCCC1,142,0,8,0,0,0,0,1478,1,354,0,76,0,0,2059
+16,1-heptanol,CCCCCCCO,313,0,77,2,0,0,0,1293,0,235,0,21,0,0,1941
+64,tert-butyl ethyl ether,CCOC(C)(C)C,32,0,24,0,0,0,0,1048,4,819,0,0,0,0,1927
+13,1-octanol,CCCCCCCCO,356,12,78,2,0,0,0,812,0,476,0,32,0,0,1768
+5,1-hexanol,CCCCCCO,664,8,64,2,0,0,0,729,0,204,0,31,0,0,1702
+57,"2,2,4-trimethylpentane",CC(C)CC(C)(C)C,45,0,12,0,0,0,0,1216,0,261,0,156,0,0,1690
+10,1-pentanol,CCCCCO,396,0,78,10,0,0,0,670,0,89,90,299,0,0,1632
+72,2-butoxyethanol,CCCCOCCO,20,0,5,0,0,0,0,781,0,562,0,38,0,0,1406
+48,"1,3-dimethylbenzene",Cc1cccc(C)c1,76,0,22,0,0,0,0,660,18,557,0,25,0,14,1372
+4,2-methyl-1-propanol,CC(C)CO,721,0,15,5,0,0,0,399,0,71,105,31,0,0,1347
+15,"1,2-ethanediol",OCCO,314,47,26,1,0,0,2,615,6,87,10,0,79,135,1322
+18,"1,2-propanediol",CC(O)CO,272,12,40,6,0,0,2,669,10,0,8,97,85,114,1315
+164,"1,2-dimethylbenzene",Cc1ccccc1C,0,0,0,0,0,0,0,663,10,592,0,29,0,14,1308
+50,2-methyl-2-propanol,CC(C)(C)O,65,0,16,0,0,0,0,1168,0,45,0,0,0,0,1294
+22,1-nonanol,CCCCCCCCCO,184,0,62,0,0,0,0,613,0,405,0,28,0,0,1292
+20,hexane,CCCCCC,196,0,93,0,0,0,0,402,14,223,0,139,0,87,1154
+39,"1,4-butanediol",OCCCCO,98,68,46,0,0,0,0,215,0,196,0,36,239,163,1061
+61,2-methyl-2-butanol,CCC(C)(C)O,37,88,43,0,0,0,0,248,16,450,0,98,0,39,1019
+26,"1,3-propanediol",OCCCO,136,47,56,0,0,0,0,406,13,132,8,36,64,104,1002
+17,nonane,CCCCCCCCC,273,0,81,6,0,0,0,379,11,38,132,79,0,0,999
+62,tetrahydropyran,C1CCOCC1,35,11,19,0,0,0,0,289,0,254,0,218,0,112,938
+58,glycerol,OCC(O)CO,43,0,0,2,0,0,0,860,10,0,8,0,0,0,923
+73,cyclopentane,C1CCCC1,18,0,15,0,0,0,0,412,6,398,0,63,0,0,912
+63,2-methoxyethanol,COCCO,35,0,10,0,0,0,0,517,17,306,0,0,0,0,885
+21,"1,2-dimethoxyethane",COCCOC,193,0,70,9,0,0,0,488,0,0,97,17,0,0,874
+30,ethylbenzene,CCc1ccccc1,110,0,14,0,0,0,0,494,8,242,0,0,0,0,868
+41,tetrahydrofuran,C1CCOC1,96,0,43,0,0,1,0,457,0,116,0,98,0,39,850
+23,"1,2-butanediol",CCC(O)CO,157,31,60,0,0,0,0,278,0,277,0,0,0,14,817
+40,bis(2-hydroxyethyl) ether,OCCOCCO,96,6,12,3,0,0,0,588,48,0,39,0,0,0,792
+51,methoxybenzene,COc1ccccc1,63,0,6,0,0,0,0,466,0,109,0,51,0,0,695
+47,"1,4-dioxane",C1COCCO1,77,0,32,3,0,0,0,241,0,243,0,47,0,0,643
+166,n-propyl alcohol,CCCO,0,0,0,0,0,0,0,357,0,66,105,84,0,0,612
+75,2-phenylethanol,OCCc1ccccc1,17,0,12,0,0,0,0,349,0,198,0,34,0,0,610
+45,"2,5,8-trioxanonane",COCCOCCOC,80,0,71,9,0,0,0,257,0,18,99,0,0,0,534
+68,"1,3-butanediol",CC(O)CCO,26,8,63,0,0,0,0,218,0,204,0,0,0,14,533
+165,isooctane,CCCCCC(C)C,0,0,0,0,0,0,0,413,0,72,0,42,0,0,527
+49,butan-2-ol,CCC(C)O,75,0,13,0,0,0,0,202,0,136,0,85,0,0,511
+172,tert-butanol,CC(C)(C)O,0,0,0,0,0,0,0,267,0,132,95,0,0,0,494
+85,1-propoxy-2-propanol,CCCOCC(C)O,10,0,10,0,0,0,0,318,0,145,0,0,0,0,483
+86,2-(2-methoxyethoxy)ethanol,COCCOCCO,10,0,4,0,0,0,0,320,0,140,0,0,0,0,474
+167,amylcarbinol,CCCCCCO,0,0,0,0,0,0,0,344,0,96,0,19,0,0,459
+33,methoxymethane,COC,108,81,0,145,0,0,0,0,23,0,0,76,0,0,433
+69,"1,3,5-trimethylbenzene",Cc1cc(C)cc(C)c1,25,0,3,0,0,0,0,285,0,115,0,0,0,0,428
+59,benzyl alcohol,OCc1ccccc1,37,0,10,0,0,0,0,90,0,156,0,128,0,0,421
+81,cyclooctane,C1CCCCCCC1,12,0,4,0,0,0,0,249,7,144,0,0,0,0,416
+103,cyclopentanol,OC1CCCC1,6,72,43,0,0,0,0,287,0,0,0,0,0,0,408
+80,"1,3-dioxolane",C1COCO1,13,0,11,0,0,0,0,204,0,148,0,0,0,0,376
+84,2-methyl-1-butanol,CCC(C)CO,11,73,43,0,0,0,0,173,15,56,0,0,0,0,371
+74,exo-tetrahydrodicyclopentadiene,C1CC2C3CCC(C3)C2C1,18,0,0,0,0,0,0,352,0,0,0,0,0,0,370
+46,trans-decalin,C1CC[C@@H]2CCCC[C@H]2C1,78,0,1,0,0,0,0,278,0,0,0,0,0,0,357
+56,isopropyl ether,CC(C)OC(C)C,47,0,22,0,0,0,0,88,0,97,0,101,0,0,355
+60,3-methyl-1-butanol,CC(C)CCO,37,0,4,0,0,0,0,235,15,52,0,0,0,0,343
+67,2-pentanol,CCCC(C)O,26,47,6,0,0,0,0,126,13,39,0,84,0,0,341
+106,1-butoxy-2-propanol,CCCCOCC(C)O,5,0,5,0,0,0,0,160,0,160,0,0,0,0,330
+168,"1,1,1-trimethanolethane",CC(CO)(CO)CO,0,0,0,0,0,0,0,324,0,0,0,0,0,0,324
+187,methyl alcohol,CO,0,0,0,0,0,0,0,129,0,0,105,87,0,0,321
+131,"1,5-pentanediol",OCCCCCO,1,42,2,0,0,0,0,269,0,0,0,0,0,0,314
+114,"ethanol, 2-propoxy-",CCCOCCO,4,0,0,3,0,0,0,151,0,73,78,0,0,0,309
+169,cyclohexanol,OC1CCCCC1,0,0,0,0,0,0,0,280,0,15,0,0,0,0,295
+24,2-hexanol,CCCCC(C)O,154,0,2,0,0,0,0,90,0,42,0,0,0,0,288
+170,cis-decalin,C1CC[C@@H]2CCCC[C@@H]2C1,0,0,0,0,0,0,0,278,0,9,0,0,0,0,287
+143,neopentyl alcohol,CC(C)(C)CO,0,61,0,0,5,0,0,213,0,0,0,0,0,0,279
+174,pentaerythritol,OCC(CO)(CO)CO,0,0,0,0,0,0,0,249,0,22,0,0,0,0,271
+171,"2-ethyl-2-(hydroxymethyl)-1,3-propanediol",CCC(CO)(CO)CO,0,0,0,0,0,0,0,270,0,0,0,0,0,0,270
+176,.alpha.-toluenol,OCc1ccccc1,0,0,0,0,0,0,0,210,0,0,0,48,0,0,258
+173,"1,6-hexanediol",OCCCCCCO,0,0,0,0,0,0,0,255,0,0,0,0,0,0,255
+147,"1,8-octanediol",OCCCCCCCCO,0,14,0,0,0,0,0,220,0,0,0,0,0,0,234
+66,"ethanol, 2-ethoxy-",CCOCCO,28,0,11,0,0,0,0,47,0,27,0,117,0,0,230
+76,"1,2-hexanediol",CCCCC(O)CO,15,5,0,0,0,0,0,96,0,0,0,0,53,60,229
+175,cycloheptanol,OC1CCCCCC1,0,0,0,0,0,0,0,222,0,0,0,0,0,0,222
+146,ribitol,OC[C@@H](O)[C@@H](O)[C@@H](O)CO,0,17,0,0,5,0,0,193,0,0,0,0,0,0,215
+134,"3,6-dioxaoctane",CCOCCOCC,1,0,0,0,0,0,0,196,0,0,0,17,0,0,214
+65,2-ethyl-1-hexanol,CCCCC(CC)CO,29,0,4,3,0,0,0,116,0,58,0,0,0,0,210
+177,"2-methyl-1,3-propanediol",CC(CO)CO,0,0,0,0,0,0,0,209,0,0,0,0,0,0,209
+95,3-methylphenol,Cc1cccc(O)c1,8,0,0,0,0,0,0,164,3,32,0,0,0,0,207
+178,n-decane,CCCCCCCCCC,0,0,0,0,0,0,0,181,5,0,0,20,0,0,206
+90,4-methylphenol,Cc1ccc(O)cc1,9,0,0,0,0,0,0,164,0,32,0,0,0,0,205
+44,triethylene glycol,OCCOCCOCCO,81,6,12,3,0,0,0,39,12,0,39,0,0,0,192
+191,2-ethoxyethanol,CCOCCO,0,0,0,0,0,0,0,44,0,44,0,104,0,0,192
+111,"3,6-dioxa-1-octanol",CCOCCOCCO,5,0,5,0,0,0,0,84,0,76,0,17,0,0,187
+184,"1,3-benzenediol",Oc1cccc(O)c1,0,0,0,0,0,0,0,142,0,35,0,0,0,0,177
+179,cyclohexylmethanol,OCC1CCCCC1,0,0,0,0,0,0,0,176,0,0,0,0,0,0,176
+186,"ether, methyl tert-pentyl",CCC(C)(C)OC,0,0,0,0,0,0,0,136,0,21,0,0,0,19,176
+180,2-cyclohexylethanol,OCCC1CCCCC1,0,0,0,0,0,0,0,175,0,0,0,0,0,0,175
+181,diethoxymethane,CCOCOCC,0,0,0,0,0,0,0,173,0,0,0,0,0,0,173
+124,3-pentanol,CCC(O)CC,3,65,80,0,6,0,0,0,11,0,0,0,0,0,165
+28,"2,5-dimethylfuran",Cc1oc(C)cc1,119,0,25,0,0,0,0,18,0,0,0,0,0,0,162
+182,cyclooctanol,OC1CCCCCCC1,0,0,0,0,0,0,0,156,0,0,0,0,0,0,156
+183,"2,2-dimethyl-1,3-propanediol",CC(C)(CO)CO,0,0,0,0,0,0,0,156,0,0,0,0,0,0,156
+87,2-methyltetrahydrofuran,CC1CCCO1,10,8,4,0,0,0,0,27,0,45,0,44,0,0,138
+185,"3-methylpentane-1,5-diol",CC(CCO)CCO,0,0,0,0,0,0,0,138,0,0,0,0,0,0,138
+31,2-methylfuran,Cc1occc1,109,0,25,0,0,0,0,0,0,0,0,0,0,0,134
+71,hexylene glycol,OCCCCCCO,23,51,49,0,0,0,0,0,0,0,0,0,0,0,123
+100,"2,5-hexanediol",CC(O)CCC(C)O,6,0,0,0,0,0,0,114,0,0,0,0,0,0,120
+27,dimethoxymethane,COCOC,119,0,0,0,0,0,0,0,0,0,0,0,0,0,119
+32,furan,o1cccc1,108,0,11,0,0,0,0,0,0,0,0,0,0,0,119
+38,2-methylpentane,CCCC(C)C,100,0,0,0,0,0,0,0,0,0,0,19,0,0,119
+34,2-methylheptane,CCCCCC(C)C,107,10,0,0,0,0,0,0,0,0,0,0,0,0,117
+43,xylene,Cc1ccccc1C,83,3,31,0,0,0,0,0,0,0,0,0,0,0,117
+52,diethyl ether,CCOCC,61,0,1,0,0,0,0,22,0,23,0,0,0,0,107
+123,isobutylbenzene,CC(C)Cc1ccccc1,3,0,3,0,0,0,0,100,0,0,0,0,0,0,106
+129,2-octanol,CCCCCCC(C)O,2,1,5,0,0,0,0,55,0,42,0,0,0,0,105
+35,"2,3-dimethylbutane",CC(C)C(C)C,101,0,0,0,0,0,0,0,0,0,0,0,0,0,101
+36,"2,2-dimethylbutane",CCC(C)(C)C,101,0,0,0,0,0,0,0,0,0,0,0,0,0,101
+37,3-methylpentane,CCC(C)CC,100,0,0,0,0,0,0,0,0,0,0,0,0,0,100
+188,tetralin,C1CCc2ccccc2C1,0,0,0,0,0,0,0,100,0,0,0,0,0,0,100
+79,"1,2,4-trimethylbenzene",CC1=CC(=C(C)C=C1)C,14,0,0,0,0,0,0,84,0,0,0,0,0,0,98
+83,2-heptanol,CCCCCC(C)O,11,1,2,0,0,0,0,42,0,42,0,0,0,0,98
+115,ethoxybenzene,CCOc1ccccc1,4,0,0,0,0,0,0,37,0,0,0,51,0,0,92
+190,2-(2-methylpropoxy)ethanol,CC(C)COCCO,0,0,0,0,0,0,0,45,0,45,0,0,0,0,90
+97,cyclohexyl alcohol,OC1CCCCC1,8,0,5,0,0,0,0,0,0,0,0,68,0,0,81
+104,"1,5-hexanediol",CC(O)CCCCO,6,0,0,0,0,0,0,75,0,0,0,0,0,0,81
+157,3-methyl-3-pentanol,CCC(C)(O)CC,0,0,80,0,0,0,0,0,0,0,0,0,0,0,80
+158,3-ethyl-3-pentanol,CCC(O)(CC)CC,0,0,80,0,0,0,0,0,0,0,0,0,0,0,80
+193,"1,2-benzenediol",Oc1ccccc1O,0,0,0,0,0,0,0,40,0,40,0,0,0,0,80
+54,2-methylpropane,CC(C)C,58,0,0,0,0,0,0,0,21,0,0,0,0,0,79
+101,ethylcyclohexane,CCC1CCCCC1,6,0,0,0,0,0,0,66,0,0,0,0,0,0,72
+102,"1,2,4-trimethylcyclohexane",CC1CCC(C)C(C)C1,6,0,0,0,0,0,0,66,0,0,0,0,0,0,72
+105,butylcyclohexane,CCCCC1CCCCC1,6,0,0,0,0,0,0,66,0,0,0,0,0,0,72
+55,butane,CCCC,50,0,0,0,0,0,0,0,21,0,0,0,0,0,71
+77,2-ethyl-1-butanol,CCC(CC)CO,15,7,48,0,0,0,0,0,0,0,0,0,0,0,70
+194,2-methylphenol,Cc1ccccc1O,0,0,0,0,0,0,0,32,3,32,0,0,0,0,67
+189,tetrole,o1cccc1,0,0,0,0,0,0,0,54,9,0,0,0,0,0,63
+204,diisopropyl,CC(C)C(C)C,0,0,0,0,0,0,0,0,0,0,0,63,0,0,63
+135,"furfuryl alcohol, tetrahydro-",OCC1CCCO1,1,0,1,0,0,0,0,30,0,30,0,0,0,0,62
+205,neohexane,CCC(C)(C)C,0,0,0,0,0,0,0,0,0,0,0,62,0,0,62
+196,"3,6-dioxa-1,8-octanediol",OCCOCCOCCO,0,0,0,0,0,0,0,26,35,0,0,0,0,0,61
+137,3-phenyl-1-propanol,OCCCc1ccccc1,1,0,0,0,0,0,0,24,0,0,0,34,0,0,59
+206,"ether, dipropyl",CCCOCCC,0,0,0,0,0,0,0,0,0,0,0,59,0,0,59
+70,ethane,CC,25,0,0,0,0,0,0,31,0,0,0,0,0,0,56
+126,"2,3-butanediol",CC(O)C(C)O,3,12,2,0,0,0,0,24,0,0,0,0,0,14,55
+195,ethyl tert-pentyl ether,CCOC(C)(C)CC,0,0,0,0,0,0,0,27,0,0,0,27,0,0,54
+89,1-methoxy-2-propanol,COCC(C)O,9,0,5,0,0,0,0,0,0,0,0,38,0,0,52
+139,2-hydroxymethylfuran,OCc1occc1,1,0,1,0,0,0,0,24,0,24,0,0,0,0,50
+144,"1,7-heptanediol",OCCCCCCCO,0,41,0,0,0,0,0,0,0,0,0,0,0,0,41
+145,3-methyl-2-butanol,CC(C)C(C)O,0,30,0,0,0,0,0,0,10,0,0,0,0,0,40
+192,xyliton,OC[C@H](O)C(O)[C@H](O)CO,0,0,0,0,0,0,0,40,0,0,0,0,0,0,40
+140,dipropylene glycol monomethyl ether,COC(C)COC(C)CO,1,0,1,0,0,0,0,18,0,18,0,0,0,0,38
+141,2-isopropoxyethanol,CC(C)OCCO,1,0,1,0,0,0,0,18,0,18,0,0,0,0,38
+82,"1,2,3,4-tetrahydronaphthalene",C1CCc2ccccc2C1,12,0,13,0,0,0,0,0,0,9,0,0,0,0,34
+113,butylbenzene,CCCCc1ccccc1,5,0,3,0,0,0,0,22,0,0,0,0,0,0,30
+91,dipropyl ether,CCCOCCC,9,0,0,0,0,0,0,0,0,0,0,20,0,0,29
+99,propylbenzene,CCCc1ccccc1,6,0,0,0,0,0,0,22,0,0,0,0,0,0,28
+128,phenol,Oc1ccccc1,2,0,0,0,0,0,0,23,0,0,0,0,0,0,25
+110,"propanol, oxybis-",OCCCOCCCO,5,18,0,0,0,0,0,0,0,0,0,0,0,0,23
+198,naphthalene,c1ccc2ccccc2c1,0,0,0,0,0,0,0,10,2,10,0,0,0,0,22
+78,pentane,CCCCC,15,0,0,0,0,0,0,0,6,0,0,0,0,0,21
+200,propane,CCC,0,0,0,0,0,0,0,0,21,0,0,0,0,0,21
+207,epoxypropane,CC1CO1,0,0,0,0,0,0,0,0,0,0,0,19,0,0,19
+197,methane,C,0,0,0,0,0,0,0,12,0,0,0,0,0,0,12
+98,isopropylbenzene,CC(C)c1ccccc1,7,0,4,0,0,0,0,0,0,0,0,0,0,0,11
+88,cyclohexene oxide,C1CCC2OC2C1,10,0,0,0,0,0,0,0,0,0,0,0,0,0,10
+109,propylene glycol monoethyl ether,CCOCC(C)O,5,0,5,0,0,0,0,0,0,0,0,0,0,0,10
+112,2-butoxy-1-propanol,CCCCOC(C)CO,5,0,5,0,0,0,0,0,0,0,0,0,0,0,10
+201,o-xylene,Cc1ccccc1C,0,0,0,0,0,0,0,0,9,0,0,0,0,0,9
+92,butyl isobutyl ether,CCCCOCC(C)C,8,0,0,0,0,0,0,0,0,0,0,0,0,0,8
+93,"ether, ethyl butyl",CCCCOCC,8,0,0,0,0,0,0,0,0,0,0,0,0,0,8
+94,ethyl hexyl ether,CCCCCCOCC,8,0,0,0,0,0,0,0,0,0,0,0,0,0,8
+96,pentyl propyl ether,CCCCCOCCC,8,0,0,0,0,0,0,0,0,0,0,0,0,0,8
+122,tert-amyl methyl ether,CCC(C)(C)OC,3,0,1,0,0,0,0,0,4,0,0,0,0,0,8
+120,methylcyclopentane,CC1CCCC1,3,0,3,0,0,0,0,0,1,0,0,0,0,0,7
+107,"1,2-pentanediol",CCCC(O)CO,5,1,0,0,0,0,0,0,0,0,0,0,0,0,6
+130,"butane, 2-ethoxy-2-methyl-",CCOC(C)(C)CC,2,0,0,0,0,0,0,0,4,0,0,0,0,0,6
+148,"cis-1,2-cyclohexanediol",O[C@H]1CCCC[C@H]1O,0,6,0,0,0,0,0,0,0,0,0,0,0,0,6
+202,cycloheptane,C1CCCCCC1,0,0,0,0,0,0,0,0,6,0,0,0,0,0,6
+108,.alpha.-methylbenzyl alcohol,CC(O)c1ccccc1,5,0,0,0,0,0,0,0,0,0,0,0,0,0,5
+159,2-methyloctane,CCCCCCC(C)C,0,0,5,0,0,0,0,0,0,0,0,0,0,0,5
+160,"nonane, 2-methyl-",CCCCCCCC(C)C,0,0,5,0,0,0,0,0,0,0,0,0,0,0,5
+161,4-methyloctane,CCCCC(C)CCC,0,0,5,0,0,0,0,0,0,0,0,0,0,0,5
+162,"octane, 3,6-dimethyl-",CCC(C)CCC(C)CC,0,0,5,0,0,0,0,0,0,0,0,0,0,0,5
+163,"heptane, 3,5-dimethyl-",CCC(C)CC(C)CC,0,0,5,0,0,0,0,0,0,0,0,0,0,0,5
+116,4-methyl-2-pentanol,CC(C)CC(C)O,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
+117,2-methyl-1-pentanol,CCCC(C)CO,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
+118,2-methyl-2-pentanol,CCCC(C)(C)O,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
+119,paraldehyde,CC1OC(C)OC(C)O1,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
+121,"2,2-dimethoxypropane",COC(C)(C)OC,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
+125,3-hexanol,CCCC(O)CC,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
+127,"1,1-diethoxyethane",CCOC(C)OCC,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
+132,"2,2-dimethyl-1,3-dioxolane",CC1(C)OCCO1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1
+133,butyl tert-butyl ether,CCCCOC(C)(C)C,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1
+136,1-ethyl-2-methylbenzene,CCc1ccccc1C,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1
+138,2-(2-propoxyethoxy)ethanol,CCCOCCOCCO,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1
+142,"2,2-dimethyl-1,3-dioxolane-4-methanol",CC1(C)OCC(CO)O1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1
+149,"1,4-cyclohexanediol, trans-",O[C@@H]1CC[C@@H](O)CC1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,1
+150,5-nonanol,CCCCC(O)CCCC,0,1,0,0,0,0,0,0,0,0,0,0,0,0,1
+151,4-heptanol,CCCC(O)CCC,0,1,0,0,0,0,0,0,0,0,0,0,0,0,1
+152,3-nonanol,CCCCCCC(O)CC,0,1,0,0,0,0,0,0,0,0,0,0,0,0,1
+153,3-octanol,CCCCCC(O)CC,0,1,0,0,0,0,0,0,0,0,0,0,0,0,1
+154,4-nonanol,CCCCCC(O)CCC,0,1,0,0,0,0,0,0,0,0,0,0,0,0,1
+155,2-nonanol,CCCCCCCC(C)O,0,1,0,0,0,0,0,0,0,0,0,0,0,0,1
+156,4-octanol,CCCCC(O)CCC,0,1,0,0,0,0,0,0,0,0,0,0,0,0,1
+199,glycidol,OCC1CO1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,1
+203,p-cymene,CC(C)c1ccc(C)cc1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,1

--- a/Initial Molecule Choices/allcomp_counts_interesting_diverse.csv
+++ b/Initial Molecule Choices/allcomp_counts_interesting_diverse.csv
@@ -1,0 +1,77 @@
+,Component,SMILES,Component Count dens pure,Component Count cpmol pure,Component Count sos pure,Component Count dielec pure,Component Count hmol pure,Component Count vmol pure,Component Count vspec pure,Component Count dens binary,Component Count actcoeff binary,Component Count sos binary,Component Count dielec binary,Component Count eme binary,Component Count emcp binary,Component Count emv binary,Component Count all
+0,water,O,634,54,183,31,0,0,39,10916,122,964,34,376,390,578,14321
+2,ethanol,CCO,1169,86,91,8,0,0,2,4585,11,408,105,507,0,23,6995
+3,1-butanol,CCCCO,1327,49,85,11,0,0,0,2773,8,897,105,581,130,71,6037
+5,heptane,CCCCCCC,1254,39,132,3,12,1,0,2147,8,560,64,202,0,14,4436
+6,1-propanol,CCCO,659,18,78,7,0,0,0,2428,6,430,0,118,0,0,3744
+7,2-propanol,CC(C)O,357,6,53,5,0,0,0,2433,6,418,105,139,0,0,3522
+11,cyclohexane,C1CCCCC1,368,21,55,0,0,11,0,1465,7,520,0,302,0,14,2763
+12,methanol,CO,606,75,142,7,0,0,0,853,5,31,515,210,0,0,2444
+15,methylcyclohexane,CC1CCCCC1,142,0,8,0,0,0,0,1478,1,354,0,76,0,0,2059
+17,tert-butyl ethyl ether,CCOC(C)(C)C,32,0,24,0,0,0,0,1048,4,819,0,0,0,0,1927
+19,1-hexanol,CCCCCCO,664,8,64,2,0,0,0,729,0,204,0,31,0,0,1702
+20,"2,2,4-trimethylpentane",CC(C)CC(C)(C)C,45,0,12,0,0,0,0,1216,0,261,0,156,0,0,1690
+21,1-pentanol,CCCCCO,396,0,78,10,0,0,0,670,0,89,90,299,0,0,1632
+24,2-methyl-1-propanol,CC(C)CO,721,0,15,5,0,0,0,399,0,71,105,31,0,0,1347
+28,2-methyl-2-propanol,CC(C)(C)O,65,0,16,0,0,0,0,1168,0,45,0,0,0,0,1294
+30,hexane,CCCCCC,196,0,93,0,0,0,0,402,14,223,0,139,0,87,1154
+32,2-methyl-2-butanol,CCC(C)(C)O,37,88,43,0,0,0,0,248,16,450,0,98,0,39,1019
+35,tetrahydropyran,C1CCOCC1,35,11,19,0,0,0,0,289,0,254,0,218,0,112,938
+37,cyclopentane,C1CCCC1,18,0,15,0,0,0,0,412,6,398,0,63,0,0,912
+38,2-methoxyethanol,COCCO,35,0,10,0,0,0,0,517,17,306,0,0,0,0,885
+41,tetrahydrofuran,C1CCOC1,96,0,43,0,0,1,0,457,0,116,0,98,0,39,850
+45,"1,4-dioxane",C1COCCO1,77,0,32,3,0,0,0,241,0,243,0,47,0,0,643
+46,n-propyl alcohol,CCCO,0,0,0,0,0,0,0,357,0,66,105,84,0,0,612
+50,isooctane,CCCCCC(C)C,0,0,0,0,0,0,0,413,0,72,0,42,0,0,527
+51,butan-2-ol,CCC(C)O,75,0,13,0,0,0,0,202,0,136,0,85,0,0,511
+52,tert-butanol,CC(C)(C)O,0,0,0,0,0,0,0,267,0,132,95,0,0,0,494
+53,1-propoxy-2-propanol,CCCOCC(C)O,10,0,10,0,0,0,0,318,0,145,0,0,0,0,483
+55,amylcarbinol,CCCCCCO,0,0,0,0,0,0,0,344,0,96,0,19,0,0,459
+56,methoxymethane,COC,108,81,0,145,0,0,0,0,23,0,0,76,0,0,433
+59,cyclooctane,C1CCCCCCC1,12,0,4,0,0,0,0,249,7,144,0,0,0,0,416
+61,"1,3-dioxolane",C1COCO1,13,0,11,0,0,0,0,204,0,148,0,0,0,0,376
+62,2-methyl-1-butanol,CCC(C)CO,11,73,43,0,0,0,0,173,15,56,0,0,0,0,371
+65,isopropyl ether,CC(C)OC(C)C,47,0,22,0,0,0,0,88,0,97,0,101,0,0,355
+66,3-methyl-1-butanol,CC(C)CCO,37,0,4,0,0,0,0,235,15,52,0,0,0,0,343
+67,2-pentanol,CCCC(C)O,26,47,6,0,0,0,0,126,13,39,0,84,0,0,341
+70,methyl alcohol,CO,0,0,0,0,0,0,0,129,0,0,105,87,0,0,321
+72,"ethanol, 2-propoxy-",CCCOCCO,4,0,0,3,0,0,0,151,0,73,78,0,0,0,309
+74,2-hexanol,CCCCC(C)O,154,0,2,0,0,0,0,90,0,42,0,0,0,0,288
+76,neopentyl alcohol,CC(C)(C)CO,0,61,0,0,5,0,0,213,0,0,0,0,0,0,279
+82,"ethanol, 2-ethoxy-",CCOCCO,28,0,11,0,0,0,0,47,0,27,0,117,0,0,230
+88,"2-methyl-1,3-propanediol",CC(CO)CO,0,0,0,0,0,0,0,209,0,0,0,0,0,0,209
+93,2-ethoxyethanol,CCOCCO,0,0,0,0,0,0,0,44,0,44,0,104,0,0,192
+97,"ether, methyl tert-pentyl",CCC(C)(C)OC,0,0,0,0,0,0,0,136,0,21,0,0,0,19,176
+103,"2,2-dimethyl-1,3-propanediol",CC(C)(CO)CO,0,0,0,0,0,0,0,156,0,0,0,0,0,0,156
+104,2-methyltetrahydrofuran,CC1CCCO1,10,8,4,0,0,0,0,27,0,45,0,44,0,0,138
+105,"3-methylpentane-1,5-diol",CC(CCO)CCO,0,0,0,0,0,0,0,138,0,0,0,0,0,0,138
+109,dimethoxymethane,COCOC,119,0,0,0,0,0,0,0,0,0,0,0,0,0,119
+111,2-methylpentane,CCCC(C)C,100,0,0,0,0,0,0,0,0,0,0,19,0,0,119
+112,2-methylheptane,CCCCCC(C)C,107,10,0,0,0,0,0,0,0,0,0,0,0,0,117
+114,diethyl ether,CCOCC,61,0,1,0,0,0,0,22,0,23,0,0,0,0,107
+117,"2,3-dimethylbutane",CC(C)C(C)C,101,0,0,0,0,0,0,0,0,0,0,0,0,0,101
+118,"2,2-dimethylbutane",CCC(C)(C)C,101,0,0,0,0,0,0,0,0,0,0,0,0,0,101
+119,3-methylpentane,CCC(C)CC,100,0,0,0,0,0,0,0,0,0,0,0,0,0,100
+122,2-heptanol,CCCCCC(C)O,11,1,2,0,0,0,0,42,0,42,0,0,0,0,98
+124,2-(2-methylpropoxy)ethanol,CC(C)COCCO,0,0,0,0,0,0,0,45,0,45,0,0,0,0,90
+130,2-methylpropane,CC(C)C,58,0,0,0,0,0,0,0,21,0,0,0,0,0,79
+134,butane,CCCC,50,0,0,0,0,0,0,0,21,0,0,0,0,0,71
+138,diisopropyl,CC(C)C(C)C,0,0,0,0,0,0,0,0,0,0,0,63,0,0,63
+140,neohexane,CCC(C)(C)C,0,0,0,0,0,0,0,0,0,0,0,62,0,0,62
+143,"ether, dipropyl",CCCOCCC,0,0,0,0,0,0,0,0,0,0,0,59,0,0,59
+144,ethane,CC,25,0,0,0,0,0,0,31,0,0,0,0,0,0,56
+150,3-methyl-2-butanol,CC(C)C(C)O,0,30,0,0,0,0,0,0,10,0,0,0,0,0,40
+153,2-isopropoxyethanol,CC(C)OCCO,1,0,1,0,0,0,0,18,0,18,0,0,0,0,38
+156,dipropyl ether,CCCOCCC,9,0,0,0,0,0,0,0,0,0,0,20,0,0,29
+161,pentane,CCCCC,15,0,0,0,0,0,0,0,6,0,0,0,0,0,21
+162,propane,CCC,0,0,0,0,0,0,0,0,21,0,0,0,0,0,21
+164,methane,C,0,0,0,0,0,0,0,12,0,0,0,0,0,0,12
+167,propylene glycol monoethyl ether,CCOCC(C)O,5,0,5,0,0,0,0,0,0,0,0,0,0,0,10
+171,"ether, ethyl butyl",CCCCOCC,8,0,0,0,0,0,0,0,0,0,0,0,0,0,8
+174,tert-amyl methyl ether,CCC(C)(C)OC,3,0,1,0,0,0,0,0,4,0,0,0,0,0,8
+175,methylcyclopentane,CC1CCCC1,3,0,3,0,0,0,0,0,1,0,0,0,0,0,7
+179,cycloheptane,C1CCCCCC1,0,0,0,0,0,0,0,0,6,0,0,0,0,0,6
+186,4-methyl-2-pentanol,CC(C)CC(C)O,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
+187,2-methyl-1-pentanol,CCCC(C)CO,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
+188,2-methyl-2-pentanol,CCCC(C)(C)O,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3
+192,"1,1-diethoxyethane",CCOC(C)OCC,3,0,0,0,0,0,0,0,0,0,0,0,0,0,3

--- a/Initial Molecule Choices/bincomp_counts_diverse.csv
+++ b/Initial Molecule Choices/bincomp_counts_diverse.csv
@@ -1,0 +1,66 @@
+,Component,SMILES,Component Count dens binary,Component Count actcoeff binary,Component Count sos binary,Component Count dielec binary,Component Count eme binary,Component Count emcp binary,Component Count emv binary,Component Count all binary
+0,water,O,10916,122,964,34,376,390,578,13380
+1,ethanol,CCO,4585,11,408,105,507,0,23,5639
+2,1-butanol,CCCCO,2773,8,897,105,581,130,71,4565
+3,heptane,CCCCCCC,3328,8,560,64,202,0,14,4176
+6,cyclohexane,C1CCCCC1,2548,7,520,0,336,0,14,3425
+8,2-propanol,CC(C)O,2433,6,418,105,139,0,0,3101
+9,1-propanol,CCCO,2428,6,430,0,118,0,0,2982
+13,methylcyclohexane,CC1CCCCC1,1478,1,354,0,76,0,0,1909
+15,tert-butyl ethyl ether,CCOC(C)(C)C,1048,4,819,0,0,0,0,1871
+16,"2,2,4-trimethylpentane",CC(C)CC(C)(C)C,1370,0,261,0,156,0,0,1787
+17,methanol,CO,853,5,31,515,210,0,0,1614
+24,2-methyl-2-propanol,CC(C)(C)O,1168,0,45,0,0,0,0,1213
+25,1-pentanol,CCCCCO,670,0,89,90,299,0,0,1148
+26,hexane,CCCCCC,651,14,223,0,157,0,87,1132
+29,1-hexanol,CCCCCCO,729,0,204,0,31,0,0,964
+32,cyclopentane,C1CCCC1,412,6,398,0,63,0,0,879
+34,tetrahydropyran,C1CCOCC1,289,0,254,0,218,0,112,873
+35,2-methyl-2-butanol,CCC(C)(C)O,248,16,450,0,98,0,39,851
+37,2-methoxyethanol,COCCO,517,17,306,0,0,0,0,840
+40,tetrahydrofuran,C1CCOC1,457,0,116,0,98,0,39,710
+43,n-propyl alcohol,CCCO,357,0,66,105,84,0,0,612
+44,2-methyl-1-propanol,CC(C)CO,399,0,71,105,31,0,0,606
+48,"1,4-dioxane",C1COCCO1,241,0,243,0,47,0,0,531
+49,isooctane,CCCCCC(C)C,413,0,72,0,42,0,0,527
+50,tert-butanol,CC(C)(C)O,267,0,132,95,0,0,0,494
+51,pentane,CCCCC,483,6,0,0,0,0,0,489
+52,1-propoxy-2-propanol,CCCOCC(C)O,318,0,145,0,0,0,0,463
+54,amylcarbinol,CCCCCCO,344,0,96,0,19,0,0,459
+56,butan-2-ol,CCC(C)O,202,0,136,0,85,0,0,423
+57,cyclooctane,C1CCCCCCC1,271,7,144,0,0,0,0,422
+62,"1,3-dioxolane",C1COCO1,204,0,148,0,0,0,0,352
+64,methyl alcohol,CO,129,0,0,105,87,0,0,321
+66,3-methyl-1-butanol,CC(C)CCO,235,15,52,0,0,0,0,302
+67,"ethanol, 2-propoxy-",CCCOCCO,151,0,73,78,0,0,0,302
+71,isopropyl ether,CC(C)OC(C)C,88,0,97,0,101,0,0,286
+76,2-pentanol,CCCC(C)O,126,13,39,0,84,0,0,262
+79,2-methyl-1-butanol,CCC(C)CO,173,15,56,0,0,0,0,244
+82,neopentyl alcohol,CC(C)(C)CO,213,0,0,0,0,0,0,213
+84,"2-methyl-1,3-propanediol",CC(CO)CO,209,0,0,0,0,0,0,209
+89,2-ethoxyethanol,CCOCCO,44,0,44,0,104,0,0,192
+90,"ethanol, 2-ethoxy-",CCOCCO,47,0,27,0,117,0,0,191
+91,butane,CCCC,163,21,0,0,0,0,0,184
+92,propane,CCC,157,21,0,0,0,0,0,178
+96,"ether, methyl tert-pentyl",CCC(C)(C)OC,136,0,21,0,0,0,19,176
+100,"2,2-dimethyl-1,3-propanediol",CC(C)(CO)CO,156,0,0,0,0,0,0,156
+102,"3-methylpentane-1,5-diol",CC(CCO)CCO,138,0,0,0,0,0,0,138
+103,2-hexanol,CCCCC(C)O,90,0,42,0,0,0,0,132
+104,2-methyltetrahydrofuran,CC1CCCO1,27,0,45,0,44,0,0,116
+108,methoxymethane,COC,0,23,0,0,76,0,0,99
+110,2-(2-methylpropoxy)ethanol,CC(C)COCCO,45,0,45,0,0,0,0,90
+114,2-heptanol,CCCCCC(C)O,42,0,42,0,0,0,0,84
+123,diisopropyl,CC(C)C(C)C,0,0,0,0,63,0,0,63
+124,neohexane,CCC(C)(C)C,0,0,0,0,62,0,0,62
+127,"ether, dipropyl",CCCOCCC,0,0,0,0,59,0,0,59
+131,diethyl ether,CCOCC,22,0,23,0,0,0,0,45
+132,ethane,CC,44,0,0,0,0,0,0,44
+136,methane,C,37,0,0,0,0,0,0,37
+138,2-isopropoxyethanol,CC(C)OCCO,18,0,18,0,0,0,0,36
+143,2-methylpropane,CC(C)C,0,21,0,0,0,0,0,21
+144,dipropyl ether,CCCOCCC,0,0,0,0,20,0,0,20
+146,2-methylpentane,CCCC(C)C,0,0,0,0,19,0,0,19
+149,3-methyl-2-butanol,CC(C)C(C)O,0,10,0,0,0,0,0,10
+152,cycloheptane,C1CCCCCC1,0,6,0,0,0,0,0,6
+154,tert-amyl methyl ether,CCC(C)(C)OC,0,4,0,0,0,0,0,4
+157,methylcyclopentane,CC1CCCC1,0,1,0,0,0,0,0,1

--- a/Initial Molecule Choices/bincomp_counts_interesting.csv
+++ b/Initial Molecule Choices/bincomp_counts_interesting.csv
@@ -1,0 +1,159 @@
+,Component,SMILES,Component Count dens binary,Component Count actcoeff binary,Component Count sos binary,Component Count dielec binary,Component Count eme binary,Component Count emcp binary,Component Count emv binary,Component Count all binary
+0,water,O,10916,122,964,34,376,390,578,13380
+1,ethanol,CCO,4585,11,408,105,507,0,23,5639
+2,1-butanol,CCCCO,2773,8,897,105,581,130,71,4565
+3,toluene,Cc1ccccc1,2663,29,660,0,158,0,14,3524
+6,methyl tert-butyl ether,COC(C)(C)C,2321,4,838,0,140,0,0,3303
+4,2-propanol,CC(C)O,2433,6,418,105,139,0,0,3101
+8,heptane,CCCCCCC,2147,8,560,64,202,0,14,2995
+5,1-propanol,CCCO,2428,6,430,0,118,0,0,2982
+7,benzene,c1ccccc1,2314,24,393,0,229,0,14,2974
+9,octane,CCCCCCCC,2022,13,226,90,94,0,0,2445
+11,cyclohexane,C1CCCCC1,1465,7,520,0,302,0,14,2308
+13,dibutyl ether,CCCCOCCCC,1271,0,349,90,576,0,0,2286
+10,methylcyclohexane,CC1CCCCC1,1478,1,354,0,76,0,0,1909
+14,"1,4-dimethylbenzene",Cc1ccc(C)cc1,1259,22,600,0,14,0,14,1909
+17,tert-butyl ethyl ether,CCOC(C)(C)C,1048,4,819,0,0,0,0,1871
+15,"2,2,4-trimethylpentane",CC(C)CC(C)(C)C,1216,0,261,0,156,0,0,1633
+19,methanol,CO,853,5,31,515,210,0,0,1614
+12,1-heptanol,CCCCCCCO,1293,0,235,0,21,0,0,1549
+21,2-butoxyethanol,CCCCOCCO,781,0,562,0,38,0,0,1381
+20,1-octanol,CCCCCCCCO,812,0,476,0,32,0,0,1320
+25,"1,2-dimethylbenzene",Cc1ccccc1C,663,10,592,0,29,0,14,1308
+26,"1,3-dimethylbenzene",Cc1cccc(C)c1,660,18,557,0,25,0,14,1274
+16,2-methyl-2-propanol,CC(C)(C)O,1168,0,45,0,0,0,0,1213
+23,1-pentanol,CCCCCO,670,0,89,90,299,0,0,1148
+28,1-nonanol,CCCCCCCCCO,613,0,405,0,28,0,0,1046
+24,"1,2-propanediol",CC(O)CO,669,10,0,8,97,85,114,983
+22,1-hexanol,CCCCCCO,729,0,204,0,31,0,0,964
+27,"1,2-ethanediol",OCCO,615,6,87,10,0,79,135,932
+36,cyclopentane,C1CCCC1,412,6,398,0,63,0,0,879
+18,glycerol,OCC(O)CO,860,10,0,8,0,0,0,878
+49,tetrahydropyran,C1CCOCC1,289,0,254,0,218,0,112,873
+38,hexane,CCCCCC,402,14,223,0,139,0,87,865
+63,2-methyl-2-butanol,CCC(C)(C)O,248,16,450,0,98,0,39,851
+69,"1,4-butanediol",OCCCCO,215,0,196,0,36,239,163,849
+30,2-methoxyethanol,COCCO,517,17,306,0,0,0,0,840
+37,"1,3-propanediol",OCCCO,406,13,132,8,36,64,104,763
+31,ethylbenzene,CCc1ccccc1,494,8,242,0,0,0,0,744
+34,tetrahydrofuran,C1CCOC1,457,0,116,0,98,0,39,710
+29,bis(2-hydroxyethyl) ether,OCCOCCO,588,48,0,39,0,0,0,675
+40,nonane,CCCCCCCCC,379,11,38,132,79,0,0,639
+33,methoxybenzene,COc1ccccc1,466,0,109,0,51,0,0,626
+41,n-propyl alcohol,CCCO,357,0,66,105,84,0,0,612
+39,2-methyl-1-propanol,CC(C)CO,399,0,71,105,31,0,0,606
+32,"1,2-dimethoxyethane",COCCOC,488,0,0,97,17,0,0,602
+44,2-phenylethanol,OCCc1ccccc1,349,0,198,0,34,0,0,581
+55,"1,2-butanediol",CCC(O)CO,278,0,277,0,0,0,14,569
+42,decane,CCCCCCCCCC,352,6,145,0,60,0,0,563
+64,"1,4-dioxane",C1COCCO1,241,0,243,0,47,0,0,531
+35,isooctane,CCCCCC(C)C,413,0,72,0,42,0,0,527
+58,tert-butanol,CC(C)(C)O,267,0,132,95,0,0,0,494
+48,1-propoxy-2-propanol,CCCOCC(C)O,318,0,145,0,0,0,0,463
+47,2-(2-methoxyethoxy)ethanol,COCCOCCO,320,0,140,0,0,0,0,460
+45,amylcarbinol,CCCCCCO,344,0,96,0,19,0,0,459
+68,"1,3-butanediol",CC(O)CCO,218,0,204,0,0,0,14,436
+74,butan-2-ol,CCC(C)O,202,0,136,0,85,0,0,423
+51,"1,3,5-trimethylbenzene",Cc1cc(C)cc(C)c1,285,0,115,0,0,0,0,400
+62,cyclooctane,C1CCCCCCC1,249,7,144,0,0,0,0,400
+59,"2,5,8-trioxanonane",COCCOCCOC,257,0,18,99,0,0,0,374
+99,benzyl alcohol,OCc1ccccc1,90,0,156,0,128,0,0,374
+43,exo-tetrahydrodicyclopentadiene,C1CC2C3CCC(C3)C2C1,352,0,0,0,0,0,0,352
+73,"1,3-dioxolane",C1COCO1,204,0,148,0,0,0,0,352
+46,"1,1,1-trimethanolethane",CC(CO)(CO)CO,324,0,0,0,0,0,0,324
+91,methyl alcohol,CO,129,0,0,105,87,0,0,321
+84,1-butoxy-2-propanol,CCCCOCC(C)O,160,0,160,0,0,0,0,320
+65,3-methyl-1-butanol,CC(C)CCO,235,15,52,0,0,0,0,302
+87,"ethanol, 2-propoxy-",CCCOCCO,151,0,73,78,0,0,0,302
+52,cyclohexanol,OC1CCCCC1,280,0,15,0,0,0,0,295
+50,cyclopentanol,OC1CCCC1,287,0,0,0,0,0,0,287
+54,cis-decalin,C1CC[C@@H]2CCCC[C@@H]2C1,278,0,9,0,0,0,0,287
+100,isopropyl ether,CC(C)OC(C)C,88,0,97,0,101,0,0,286
+53,trans-decalin,C1CC[C@@H]2CCCC[C@H]2C1,278,0,0,0,0,0,0,278
+61,pentaerythritol,OCC(CO)(CO)CO,249,0,22,0,0,0,0,271
+56,"2-ethyl-2-(hydroxymethyl)-1,3-propanediol",CCC(CO)(CO)CO,270,0,0,0,0,0,0,270
+57,"1,5-pentanediol",OCCCCCO,269,0,0,0,0,0,0,269
+92,2-pentanol,CCCC(C)O,126,13,39,0,84,0,0,262
+71,.alpha.-toluenol,OCc1ccccc1,210,0,0,0,48,0,0,258
+60,"1,6-hexanediol",OCCCCCCO,255,0,0,0,0,0,0,255
+80,2-methyl-1-butanol,CCC(C)CO,173,15,56,0,0,0,0,244
+66,cycloheptanol,OC1CCCCCC1,222,0,0,0,0,0,0,222
+67,"1,8-octanediol",OCCCCCCCCO,220,0,0,0,0,0,0,220
+70,neopentyl alcohol,CC(C)(C)CO,213,0,0,0,0,0,0,213
+75,"3,6-dioxaoctane",CCOCCOCC,196,0,0,0,17,0,0,213
+72,"2-methyl-1,3-propanediol",CC(CO)CO,209,0,0,0,0,0,0,209
+97,"1,2-hexanediol",CCCCC(O)CO,96,0,0,0,0,53,60,209
+77,n-decane,CCCCCCCCCC,181,5,0,0,20,0,0,206
+83,3-methylphenol,Cc1cccc(O)c1,164,3,32,0,0,0,0,199
+82,4-methylphenol,Cc1ccc(O)cc1,164,0,32,0,0,0,0,196
+76,ribitol,OC[C@@H](O)[C@@H](O)[C@@H](O)CO,193,0,0,0,0,0,0,193
+111,2-ethoxyethanol,CCOCCO,44,0,44,0,104,0,0,192
+109,"ethanol, 2-ethoxy-",CCOCCO,47,0,27,0,117,0,0,191
+88,"1,3-benzenediol",Oc1cccc(O)c1,142,0,35,0,0,0,0,177
+101,"3,6-dioxa-1-octanol",CCOCCOCCO,84,0,76,0,17,0,0,177
+78,cyclohexylmethanol,OCC1CCCCC1,176,0,0,0,0,0,0,176
+90,"ether, methyl tert-pentyl",CCC(C)(C)OC,136,0,21,0,0,0,19,176
+79,2-cyclohexylethanol,OCCC1CCCCC1,175,0,0,0,0,0,0,175
+93,2-ethyl-1-hexanol,CCCCC(CC)CO,116,0,58,0,0,0,0,174
+81,diethoxymethane,CCOCOCC,173,0,0,0,0,0,0,173
+85,cyclooctanol,OC1CCCCCCC1,156,0,0,0,0,0,0,156
+86,"2,2-dimethyl-1,3-propanediol",CC(C)(CO)CO,156,0,0,0,0,0,0,156
+89,"3-methylpentane-1,5-diol",CC(CCO)CCO,138,0,0,0,0,0,0,138
+98,2-hexanol,CCCCC(C)O,90,0,42,0,0,0,0,132
+120,2-methyltetrahydrofuran,CC1CCCO1,27,0,45,0,44,0,0,116
+94,"2,5-hexanediol",CC(O)CCC(C)O,114,0,0,0,0,0,0,114
+95,isobutylbenzene,CC(C)Cc1ccccc1,100,0,0,0,0,0,0,100
+96,tetralin,C1CCc2ccccc2C1,100,0,0,0,0,0,0,100
+136,methoxymethane,COC,0,23,0,0,76,0,0,99
+107,2-octanol,CCCCCCC(C)O,55,0,42,0,0,0,0,97
+110,2-(2-methylpropoxy)ethanol,CC(C)COCCO,45,0,45,0,0,0,0,90
+115,triethylene glycol,OCCOCCOCCO,39,12,0,39,0,0,0,90
+116,ethoxybenzene,CCOc1ccccc1,37,0,0,0,51,0,0,88
+102,"1,2,4-trimethylbenzene",CC1=CC(=C(C)C=C1)C,84,0,0,0,0,0,0,84
+112,2-heptanol,CCCCCC(C)O,42,0,42,0,0,0,0,84
+114,"1,2-benzenediol",Oc1ccccc1O,40,0,40,0,0,0,0,80
+103,"1,5-hexanediol",CC(O)CCCCO,75,0,0,0,0,0,0,75
+150,cyclohexyl alcohol,OC1CCCCC1,0,0,0,0,68,0,0,68
+117,2-methylphenol,Cc1ccccc1O,32,3,32,0,0,0,0,67
+104,"1,2,4-trimethylcyclohexane",CC1CCC(C)C(C)C1,66,0,0,0,0,0,0,66
+105,butylcyclohexane,CCCCC1CCCCC1,66,0,0,0,0,0,0,66
+106,ethylcyclohexane,CCC1CCCCC1,66,0,0,0,0,0,0,66
+108,tetrole,o1cccc1,54,9,0,0,0,0,0,63
+151,diisopropyl,CC(C)C(C)C,0,0,0,0,63,0,0,63
+152,neohexane,CCC(C)(C)C,0,0,0,0,62,0,0,62
+122,"3,6-dioxa-1,8-octanediol",OCCOCCOCCO,26,35,0,0,0,0,0,61
+119,"furfuryl alcohol, tetrahydro-",OCC1CCCO1,30,0,30,0,0,0,0,60
+153,"ether, dipropyl",CCCOCCC,0,0,0,0,59,0,0,59
+123,3-phenyl-1-propanol,OCCCc1ccccc1,24,0,0,0,34,0,0,58
+121,ethyl tert-pentyl ether,CCOC(C)(C)CC,27,0,0,0,27,0,0,54
+124,2-hydroxymethylfuran,OCc1occc1,24,0,24,0,0,0,0,48
+129,diethyl ether,CCOCC,22,0,23,0,0,0,0,45
+113,xyliton,OC[C@H](O)C(O)[C@H](O)CO,40,0,0,0,0,0,0,40
+125,"2,3-butanediol",CC(O)C(C)O,24,0,0,0,0,0,14,38
+154,1-methoxy-2-propanol,COCC(C)O,0,0,0,0,38,0,0,38
+131,dipropylene glycol monomethyl ether,COC(C)COC(C)CO,18,0,18,0,0,0,0,36
+132,2-isopropoxyethanol,CC(C)OCCO,18,0,18,0,0,0,0,36
+118,ethane,CC,31,0,0,0,0,0,0,31
+126,phenol,Oc1ccccc1,23,0,0,0,0,0,0,23
+127,propylbenzene,CCCc1ccccc1,22,0,0,0,0,0,0,22
+128,butylbenzene,CCCCc1ccccc1,22,0,0,0,0,0,0,22
+134,naphthalene,c1ccc2ccccc2c1,10,2,10,0,0,0,0,22
+137,butane,CCCC,0,21,0,0,0,0,0,21
+138,2-methylpropane,CC(C)C,0,21,0,0,0,0,0,21
+139,propane,CCC,0,21,0,0,0,0,0,21
+155,dipropyl ether,CCCOCCC,0,0,0,0,20,0,0,20
+156,2-methylpentane,CCCC(C)C,0,0,0,0,19,0,0,19
+157,epoxypropane,CC1CO1,0,0,0,0,19,0,0,19
+130,"2,5-dimethylfuran",Cc1oc(C)cc1,18,0,0,0,0,0,0,18
+133,methane,C,12,0,0,0,0,0,0,12
+140,3-pentanol,CCC(O)CC,0,11,0,0,0,0,0,11
+141,3-methyl-2-butanol,CC(C)C(C)O,0,10,0,0,0,0,0,10
+142,o-xylene,Cc1ccccc1C,0,9,0,0,0,0,0,9
+149,"1,2,3,4-tetrahydronaphthalene",C1CCc2ccccc2C1,0,0,9,0,0,0,0,9
+143,cycloheptane,C1CCCCCC1,0,6,0,0,0,0,0,6
+144,pentane,CCCCC,0,6,0,0,0,0,0,6
+145,"butane, 2-ethoxy-2-methyl-",CCOC(C)(C)CC,0,4,0,0,0,0,0,4
+146,tert-amyl methyl ether,CCC(C)(C)OC,0,4,0,0,0,0,0,4
+135,glycidol,OCC1CO1,1,0,0,0,0,0,0,1
+147,p-cymene,CC(C)c1ccc(C)cc1,0,1,0,0,0,0,0,1
+148,methylcyclopentane,CC1CCCC1,0,1,0,0,0,0,0,1

--- a/Initial Molecule Choices/bincomp_counts_interesting_diverse.csv
+++ b/Initial Molecule Choices/bincomp_counts_interesting_diverse.csv
@@ -1,0 +1,66 @@
+,Component,SMILES,Component Count dens binary,Component Count actcoeff binary,Component Count sos binary,Component Count dielec binary,Component Count eme binary,Component Count emcp binary,Component Count emv binary,Component Count all binary
+0,water,O,10916,122,964,34,376,390,578,13380
+1,ethanol,CCO,4585,11,408,105,507,0,23,5639
+2,1-butanol,CCCCO,2773,8,897,105,581,130,71,4565
+5,2-propanol,CC(C)O,2433,6,418,105,139,0,0,3101
+6,heptane,CCCCCCC,2147,8,560,64,202,0,14,2995
+7,1-propanol,CCCO,2428,6,430,0,118,0,0,2982
+10,cyclohexane,C1CCCCC1,1465,7,520,0,302,0,14,2308
+12,methylcyclohexane,CC1CCCCC1,1478,1,354,0,76,0,0,1909
+14,tert-butyl ethyl ether,CCOC(C)(C)C,1048,4,819,0,0,0,0,1871
+15,"2,2,4-trimethylpentane",CC(C)CC(C)(C)C,1216,0,261,0,156,0,0,1633
+16,methanol,CO,853,5,31,515,210,0,0,1614
+22,2-methyl-2-propanol,CC(C)(C)O,1168,0,45,0,0,0,0,1213
+23,1-pentanol,CCCCCO,670,0,89,90,299,0,0,1148
+26,1-hexanol,CCCCCCO,729,0,204,0,31,0,0,964
+28,cyclopentane,C1CCCC1,412,6,398,0,63,0,0,879
+30,tetrahydropyran,C1CCOCC1,289,0,254,0,218,0,112,873
+31,hexane,CCCCCC,402,14,223,0,139,0,87,865
+32,2-methyl-2-butanol,CCC(C)(C)O,248,16,450,0,98,0,39,851
+34,2-methoxyethanol,COCCO,517,17,306,0,0,0,0,840
+37,tetrahydrofuran,C1CCOC1,457,0,116,0,98,0,39,710
+41,n-propyl alcohol,CCCO,357,0,66,105,84,0,0,612
+42,2-methyl-1-propanol,CC(C)CO,399,0,71,105,31,0,0,606
+47,"1,4-dioxane",C1COCCO1,241,0,243,0,47,0,0,531
+48,isooctane,CCCCCC(C)C,413,0,72,0,42,0,0,527
+49,tert-butanol,CC(C)(C)O,267,0,132,95,0,0,0,494
+50,1-propoxy-2-propanol,CCCOCC(C)O,318,0,145,0,0,0,0,463
+52,amylcarbinol,CCCCCCO,344,0,96,0,19,0,0,459
+54,butan-2-ol,CCC(C)O,202,0,136,0,85,0,0,423
+56,cyclooctane,C1CCCCCCC1,249,7,144,0,0,0,0,400
+60,"1,3-dioxolane",C1COCO1,204,0,148,0,0,0,0,352
+62,methyl alcohol,CO,129,0,0,105,87,0,0,321
+64,3-methyl-1-butanol,CC(C)CCO,235,15,52,0,0,0,0,302
+65,"ethanol, 2-propoxy-",CCCOCCO,151,0,73,78,0,0,0,302
+69,isopropyl ether,CC(C)OC(C)C,88,0,97,0,101,0,0,286
+74,2-pentanol,CCCC(C)O,126,13,39,0,84,0,0,262
+77,2-methyl-1-butanol,CCC(C)CO,173,15,56,0,0,0,0,244
+80,neopentyl alcohol,CC(C)(C)CO,213,0,0,0,0,0,0,213
+82,"2-methyl-1,3-propanediol",CC(CO)CO,209,0,0,0,0,0,0,209
+88,2-ethoxyethanol,CCOCCO,44,0,44,0,104,0,0,192
+89,"ethanol, 2-ethoxy-",CCOCCO,47,0,27,0,117,0,0,191
+93,"ether, methyl tert-pentyl",CCC(C)(C)OC,136,0,21,0,0,0,19,176
+98,"2,2-dimethyl-1,3-propanediol",CC(C)(CO)CO,156,0,0,0,0,0,0,156
+99,"3-methylpentane-1,5-diol",CC(CCO)CCO,138,0,0,0,0,0,0,138
+100,2-hexanol,CCCCC(C)O,90,0,42,0,0,0,0,132
+101,2-methyltetrahydrofuran,CC1CCCO1,27,0,45,0,44,0,0,116
+105,methoxymethane,COC,0,23,0,0,76,0,0,99
+107,2-(2-methylpropoxy)ethanol,CC(C)COCCO,45,0,45,0,0,0,0,90
+111,2-heptanol,CCCCCC(C)O,42,0,42,0,0,0,0,84
+120,diisopropyl,CC(C)C(C)C,0,0,0,0,63,0,0,63
+121,neohexane,CCC(C)(C)C,0,0,0,0,62,0,0,62
+124,"ether, dipropyl",CCCOCCC,0,0,0,0,59,0,0,59
+128,diethyl ether,CCOCC,22,0,23,0,0,0,0,45
+133,2-isopropoxyethanol,CC(C)OCCO,18,0,18,0,0,0,0,36
+134,ethane,CC,31,0,0,0,0,0,0,31
+139,butane,CCCC,0,21,0,0,0,0,0,21
+140,2-methylpropane,CC(C)C,0,21,0,0,0,0,0,21
+141,propane,CCC,0,21,0,0,0,0,0,21
+142,dipropyl ether,CCCOCCC,0,0,0,0,20,0,0,20
+143,2-methylpentane,CCCC(C)C,0,0,0,0,19,0,0,19
+146,methane,C,12,0,0,0,0,0,0,12
+148,3-methyl-2-butanol,CC(C)C(C)O,0,10,0,0,0,0,0,10
+151,cycloheptane,C1CCCCCC1,0,6,0,0,0,0,0,6
+152,pentane,CCCCC,0,6,0,0,0,0,0,6
+154,tert-amyl methyl ether,CCC(C)(C)OC,0,4,0,0,0,0,0,4
+157,methylcyclopentane,CC1CCCC1,0,1,0,0,0,0,0,1

--- a/Initial Molecule Choices/mix_counts_all.csv
+++ b/Initial Molecule Choices/mix_counts_all.csv
@@ -1,699 +1,699 @@
-,Mixture,Mixture Count dens binary,Mixture Count actcoeff binary,Mixture Count sos binary,Mixture Count dielec binary,Mixture Count eme binary,Mixture Count emcp binary,Mixture Count emv binary,Mixture Count all
-0,benzene__octane,1067,0,13,0,0,0,0,1080
-2,2-propanol__water,1012,0,0,0,45,0,0,1057
-1,cyclohexane__nonane,1031,0,0,0,0,0,0,1031
-3,1-propanol__toluene,842,0,0,0,0,0,0,842
-9,ethanol__water,712,0,20,0,83,0,0,815
-8,ethanol__toluene,723,0,71,0,0,0,0,794
-5,ethanol__methylcyclohexane,753,0,11,0,0,0,0,764
-4,1-heptanol__heptane,756,0,0,0,0,0,0,756
-6,n-octane__n-decane,750,0,0,0,0,0,0,750
-7,n-decane__heptane,750,0,0,0,0,0,0,750
-10,ethanol__heptane,708,0,39,0,0,0,0,747
-11,2-methyl-2-propanol__water,636,0,6,0,0,0,0,642
-12,1-butanol__cyclohexane,501,0,51,0,38,0,0,590
-89,tert-pentyl alcohol__heptane,102,0,450,0,0,0,0,552
-63,"1,4-butanediol__water",142,0,142,0,36,109,109,538
-17,1-propoxy-2-propanol__water,318,0,145,0,0,0,0,463
-13,glycerol__water,381,5,0,8,0,0,0,394
-38,"1,2-dimethylbenzene__methyl tert-butyl ether",195,0,195,0,0,0,0,390
-39,"1,3-dimethylbenzene__tert-butyl ethyl ether",195,0,195,0,0,0,0,390
-40,"1,3-dimethylbenzene__methyl tert-butyl ether",195,0,195,0,0,0,0,390
-41,"1,2-dimethylbenzene__tert-butyl ethyl ether",195,0,195,0,0,0,0,390
-42,"1,4-dimethylbenzene__methyl tert-butyl ether",195,0,195,0,0,0,0,390
-43,"1,4-dimethylbenzene__tert-butyl ethyl ether",195,0,195,0,0,0,0,390
-33,methanol__water,212,0,12,0,140,0,0,364
-14,tert-butanol__water,360,0,0,0,0,0,0,360
-27,1-hexanol__dibutyl ether,254,0,54,0,20,0,0,328
-15,"1,1,1-trimethanolethane__water",324,0,0,0,0,0,0,324
-16,n-butyl alcohol__2-methylheptane,324,0,0,0,0,0,0,324
-25,benzene__cyclohexane,262,0,44,0,0,0,0,306
-84,"1,3-propanediol__water",106,0,0,8,36,64,90,304
-18,n-butyl alcohol__butyl oxide,300,0,0,0,0,0,0,300
-21,cyclohexanol__water,280,0,15,0,0,0,0,295
-19,cyclopentanol__water,287,0,0,0,0,0,0,287
-20,bis(2-hydroxyethyl) ether__water,280,0,0,0,0,0,0,280
-22,cis-decalin__trans-decalin,278,0,0,0,0,0,0,278
-71,.beta.-butylene glycol__water,138,0,138,0,0,0,0,276
-23,"2-ethyl-2-(hydroxymethyl)-1,3-propanediol__water",270,0,0,0,0,0,0,270
-24,"1,5-pentanediol__water",269,0,0,0,0,0,0,269
-354,"1,2-propanediol__water",22,0,0,8,36,85,114,265
-26,"1,6-hexanediol__water",255,0,0,0,0,0,0,255
-75,"1-heptanol__1,4-dioxane",126,0,126,0,0,0,0,252
-333,"1,2-ethanediol__water",26,0,0,10,0,79,135,250
-184,ethanol__methanol,63,0,0,105,76,0,0,244
-28,"1,4-dimethylbenzene__octane",242,0,0,0,0,0,0,242
-31,tetrahydrofuran__water,220,0,20,0,0,0,0,240
-29,cycloheptanol__water,222,0,0,0,0,0,0,222
-35,1-propanol__dibutyl ether,200,0,0,0,21,0,0,221
-30,"1,8-octanediol__water",220,0,0,0,0,0,0,220
-108,1-butanol__toluene,88,0,88,0,38,0,0,214
-32,neopentyl alcohol__water,213,0,0,0,0,0,0,213
-46,"1,4-dimethylbenzene__decane",180,0,33,0,0,0,0,213
-96,"1-butanol__2,2,4-trimethylpentane",93,0,80,0,38,0,0,211
-34,"2-methyl-1,3-propanediol__water",209,0,0,0,0,0,0,209
-44,2-butoxyethanol__water,191,0,18,0,0,0,0,209
-95,"1,2-hexanediol__water",96,0,0,0,0,53,60,209
-45,decane__methyl tert-butyl ether,181,0,0,0,20,0,0,201
-36,2-propanol__dibutyl ether,200,0,0,0,0,0,0,200
-51,1-propanol__water,172,0,27,0,0,0,0,199
-37,"3,6-dioxaoctane__water",196,0,0,0,0,0,0,196
-74,2-phenylethanol__2-propanol,129,0,66,0,0,0,0,195
-205,1-butanol__dibutyl ether,55,0,55,0,84,0,0,194
-49,nonane__methyl tert-butyl ether,173,0,0,0,20,0,0,193
-70,1-butanol__benzene,138,0,0,0,51,0,0,189
-47,cyclohexylmethanol__water,176,0,0,0,0,0,0,176
-48,2-cyclohexylethanol__water,175,0,0,0,0,0,0,175
-186,1-butanol__hexane,60,0,60,0,23,0,31,174
-50,diethoxymethane__water,173,0,0,0,0,0,0,173
-57,"2,5,8-trioxanonane__water",154,0,18,0,0,0,0,172
-52,n-octane__nonane,171,0,0,0,0,0,0,171
-59,"ethanol__2,2,4-trimethylpentane",150,0,0,0,19,0,0,169
-53,pentaerythritol__water,165,0,0,0,0,0,0,165
-127,2-propanol__cyclohexane,78,0,78,0,9,0,0,165
-123,1-octanol__1-butoxy-2-propanol,80,0,80,0,0,0,0,160
-124,1-hexanol__1-butoxy-2-propanol,80,0,80,0,0,0,0,160
-54,propane__butane,157,0,0,0,0,0,0,157
-55,cyclooctanol__water,156,0,0,0,0,0,0,156
-56,"2,2-dimethyl-1,3-propanediol__water",156,0,0,0,0,0,0,156
-137,"toluene__2,2,4-trimethylpentane",77,0,77,0,0,0,0,154
-58,methanol__methyl tert-butyl ether,151,0,0,0,0,0,0,151
-80,ethanol__cyclohexane,111,0,39,0,0,0,0,150
-60,hexane__heptane,149,0,0,0,0,0,0,149
-141,"dibutyl ether__ethanol, 2-propoxy-",73,0,73,0,0,0,0,146
-61,2-propanol__methyl tert-butyl ether,144,0,0,0,0,0,0,144
-62,butan-1-ol__methyl tert-butyl ether,144,0,0,0,0,0,0,144
-143,ethanol__isooctane,72,0,72,0,0,0,0,144
-214,"butan-1-ol__butane, 1,4-dihydroxy-",50,0,54,0,0,0,40,144
-64,propan-1-ol__methyl tert-butyl ether,140,0,0,0,0,0,0,140
-65,ethanol__methyl tert-butyl ether,140,0,0,0,0,0,0,140
-66,pentan-1-ol__methyl tert-butyl ether,140,0,0,0,0,0,0,140
-67,pentylcarbinol__methyl tert-butyl ether,140,0,0,0,0,0,0,140
-145,2-butoxyethanol__1-octanol,70,0,70,0,0,0,0,140
-146,1-propanol__2-butoxyethanol,70,0,70,0,0,0,0,140
-147,2-butanol__2-butoxyethanol,70,0,70,0,0,0,0,140
-148,2-propanol__2-butoxyethanol,70,0,70,0,0,0,0,140
-149,1-hexanol__2-butoxyethanol,70,0,70,0,0,0,0,140
-150,1-butanol__2-butoxyethanol,70,0,70,0,0,0,0,140
-68,ribitol__water,139,0,0,0,0,0,0,139
-69,"3-methylpentane-1,5-diol__water",138,0,0,0,0,0,0,138
-72,pentane__nonane,138,0,0,0,0,0,0,138
-111,methylcyclohexane__toluene,85,0,50,0,0,0,0,135
-113,benzene__methylcyclohexane,85,0,50,0,0,0,0,135
-152,"nonane__2,5,8-trioxanonane",69,0,0,66,0,0,0,135
-77,ethanol__2-methyl-1-butanol,116,0,18,0,0,0,0,134
-197,1-octanol__dibutyl ether,56,0,56,0,22,0,0,134
-153,1-butanol__methyl tert-butyl ether,67,0,66,0,0,0,0,133
-97,toluene__cyclohexane,93,0,39,0,0,0,0,132
-154,"benzenemethanol__1,2-butanediol",66,0,66,0,0,0,0,132
-156,2-phenylethanol__1-propanol,66,0,66,0,0,0,0,132
-157,1-propanol__tert-butanol,66,0,66,0,0,0,0,132
-159,"2-phenylethanol__1,2-butanediol",66,0,66,0,0,0,0,132
-160,2-propanol__tert-butanol,66,0,66,0,0,0,0,132
-161,"(RS)-2-butanol__1,2-butanediol",66,0,66,0,0,0,0,132
-163,"1,2-dimethoxyethane__nonane",66,0,0,66,0,0,0,132
-165,"2-propanol__1,3-propanediol",66,0,66,0,0,0,0,132
-171,"1,3-butanediol__1,2-butanediol",66,0,66,0,0,0,0,132
-172,"1-propanol__1,3-propanediol",66,0,66,0,0,0,0,132
-73,1-propanol__benzene,131,0,0,0,0,0,0,131
-195,1-pentanol__dibutyl ether,56,0,56,0,19,0,0,131
-697,"1-butanol__1,4-butanediol",0,0,0,0,0,130,0,130
-176,octane__methyl tert-butyl ether,64,0,65,0,0,0,0,129
-179,1-butanol__2-(2-methoxyethoxy)ethanol,63,0,63,0,0,0,0,126
-185,2-methoxyethanol__2-(2-methoxyethoxy)ethanol,61,0,61,0,0,0,0,122
-76,methanol__benzene,121,0,0,0,0,0,0,121
-189,"1-butanol__3,6-dioxa-1-octanol",60,0,60,0,0,0,0,120
-266,ethanol__hexane,39,0,39,0,17,0,23,118
-78,"2,5-hexanediol__water",114,0,0,0,0,0,0,114
-79,pentane__n-octane,114,0,0,0,0,0,0,114
-192,2-methoxyethanol__2-butoxyethanol,57,0,57,0,0,0,0,114
-281,benzene__tetrahydropyran,36,0,50,0,14,0,14,114
-284,toluene__tetrahydropyran,36,0,50,0,14,0,14,114
-228,1-butanol__octane,48,0,48,0,16,0,0,112
-199,"2,2,4-trimethylpentane__methyl tert-butyl ether",55,0,55,0,0,0,0,110
-200,1-heptanol__dibutyl ether,55,0,55,0,0,0,0,110
-81,"1-propanol__2,2,4-trimethylpentane",108,0,0,0,0,0,0,108
-82,pentane__heptane,107,0,0,0,0,0,0,107
-83,glycerin__water,107,0,0,0,0,0,0,107
-100,2-(2-methoxyethoxy)ethanol__water,91,0,16,0,0,0,0,107
-121,"1,4-dimethylbenzene__cyclohexane",81,0,26,0,0,0,0,107
-142,"1,3-benzenediol__water",72,0,35,0,0,0,0,107
-85,propylene glycol__water,106,0,0,0,0,0,0,106
-118,"2,2-bis(hydroxymethyl)-1,3-propanediol__water",84,0,22,0,0,0,0,106
-86,methanol__ethylbenzene,105,0,0,0,0,0,0,105
-87,2-methoxyethanol__tert-butyl ethyl ether,105,0,0,0,0,0,0,105
-88,2-(2-methoxyethoxy)ethanol__tert-butyl ethyl ether,105,0,0,0,0,0,0,105
-592,methanol__2-propanol,0,0,0,105,0,0,0,105
-593,methanol__2-methyl-1-propanol,0,0,0,105,0,0,0,105
-594,methanol__1-butanol,0,0,0,105,0,0,0,105
-595,methanol__1-propanol,0,0,0,105,0,0,0,105
-193,toluene__methyl tert-butyl ether,57,0,46,0,0,0,0,103
-233,"1,2-ethanediol__1-nonanol",48,0,55,0,0,0,0,103
-177,1-propanol__cyclopentane,63,0,39,0,0,0,0,102
-105,toluene__octane,88,0,13,0,0,0,0,101
-90,pentane__hexane,100,0,0,0,0,0,0,100
-91,tetralin__isobutylbenzene,100,0,0,0,0,0,0,100
-92,heptane__methyl tert-butyl ether,99,0,0,0,0,0,0,99
-93,ethanol__3-methyl-1-butanol,98,0,0,0,0,0,0,98
-94,ethanol__2-methyl-2-butanol,98,0,0,0,0,0,0,98
-190,"1,4-dimethylbenzene__methylcyclohexane",59,0,37,0,0,0,0,96
-191,"1,3,5-trimethylbenzene__methylcyclohexane",59,0,37,0,0,0,0,96
-215,ethylbenzene__1-nonanol,48,0,48,0,0,0,0,96
-216,benzene__2-ethyl-1-hexanol,48,0,48,0,0,0,0,96
-217,2-methoxyethanol__1-octanol,48,0,48,0,0,0,0,96
-218,"1,3-dimethylbenzene__1-nonanol",48,0,48,0,0,0,0,96
-223,2-methoxyethanol__1-hexanol,48,0,48,0,0,0,0,96
-224,"1,4-dimethylbenzene__1-nonanol",48,0,48,0,0,0,0,96
-225,tetrahydrofuran__n-hexyl alcohol,48,0,48,0,0,0,0,96
-226,octane__1-octanol,48,0,48,0,0,0,0,96
-229,1-octanol__decane,48,0,48,0,0,0,0,96
-230,hexane__1-octanol,48,0,48,0,0,0,0,96
-232,1-butanol__decane,48,0,48,0,0,0,0,96
-235,"1,2-dimethylbenzene__1-nonanol",48,0,48,0,0,0,0,96
-236,tetrahydrofuran__octyl alcohol,48,0,48,0,0,0,0,96
-596,methanol__2-methyl-2-propanol,0,0,0,95,0,0,0,95
-138,1-butanol__water,75,8,11,0,0,0,0,94
-320,1-butanol__2-methyltetrahydrofuran,27,0,34,0,33,0,0,94
-98,"1,2-dimethoxyethane__water",93,0,0,0,0,0,0,93
-203,1-butanol__heptane,55,0,0,0,38,0,0,93
-99,"benzene__2,2,4-trimethylpentane",92,0,0,0,0,0,0,92
-209,ethylbenzene__methylcyclohexane,52,0,39,0,0,0,0,91
-101,oxacyclopentane__water,90,0,0,0,0,0,0,90
-241,2-butoxyethan-1-ol__water,45,0,45,0,0,0,0,90
-245,2-(2-methylpropoxy)ethanol__water,45,0,45,0,0,0,0,90
-213,1-propanol__cyclohexane,50,0,39,0,0,0,0,89
-269,1-butanol__cyclopentane,39,0,39,0,11,0,0,89
-102,ethyl alcohol__n-butyl alcohol,88,0,0,0,0,0,0,88
-103,"glycerol__1,2-propanediol",88,0,0,0,0,0,0,88
-104,"glycerol__1,3-propanediol",88,0,0,0,0,0,0,88
-106,glycerol__2-propanol,88,0,0,0,0,0,0,88
-107,ethyl alcohol__pentan-1-ol,88,0,0,0,0,0,0,88
-109,ethyl alcohol__propan-1-ol,88,0,0,0,0,0,0,88
-110,glycerol__1-propanol,88,0,0,0,0,0,0,88
-246,"2-methoxyethanol__ethanol, 2-ethoxy-",44,0,44,0,0,0,0,88
-112,"1,2-dihydroxyethane__water",85,0,0,0,0,0,0,85
-140,"2-propanol__1,3-dioxolane",74,0,11,0,0,0,0,85
-114,"2-propanol__pentane, 2,2,4-trimethyl-",84,0,0,0,0,0,0,84
-115,"tetrahydropyran__pentane, 2,2,4-trimethyl-",84,0,0,0,0,0,0,84
-116,"1-hexanol__2,2,4-trimethylpentane",84,0,0,0,0,0,0,84
-117,"1-heptanol__2,2,4-trimethylpentane",84,0,0,0,0,0,0,84
-119,2-propanol__tetrahydropyran,84,0,0,0,0,0,0,84
-120,ethanol__benzyl alcohol,84,0,0,0,0,0,0,84
-252,toluene__2-hexanol,42,0,42,0,0,0,0,84
-255,toluene__2-heptanol,42,0,42,0,0,0,0,84
-257,toluene__2-octanol,42,0,42,0,0,0,0,84
-305,1-butanol__methylcyclohexane,33,0,11,0,38,0,0,82
-122,1-butanol__2-methyl-1-propanol,81,0,0,0,0,0,0,81
-261,"1,2-benzenediol__water",40,0,40,0,0,0,0,80
-125,2-methyl-1-propanol__water,79,0,0,0,0,0,0,79
-126,"1-pentanol__2,2,4-trimethylpentane",79,0,0,0,0,0,0,79
-263,2-propanol__cyclopentane,39,0,39,0,0,0,0,78
-264,ethanol__cyclopentane,39,0,39,0,0,0,0,78
-265,toluene__tert-butyl ethyl ether,39,0,39,0,0,0,0,78
-267,"bis(2-hydroxyethyl) ether__ethanol, 2-propoxy-",39,0,0,39,0,0,0,78
-268,"triethylene glycol__ethanol, 2-propoxy-",39,0,0,39,0,0,0,78
-271,ethylbenzene__tert-butyl ethyl ether,39,0,39,0,0,0,0,78
-272,benzene__tert-butyl ethyl ether,39,0,39,0,0,0,0,78
-273,ethylbenzene__cyclohexane,39,0,39,0,0,0,0,78
-274,2-methyl-2-propanol__tert-butyl ethyl ether,39,0,39,0,0,0,0,78
-275,"2,2,4-trimethylpentane__tert-butyl ethyl ether",39,0,39,0,0,0,0,78
-276,cyclopentane__2-pentanol,39,0,39,0,0,0,0,78
-277,2-methyl-2-butanol__tetrahydrofuran,39,0,0,0,0,0,39,78
-279,ethanol__tert-butyl ethyl ether,39,0,39,0,0,0,0,78
-128,"1,2-ethanediol__3-methylphenol",77,0,0,0,0,0,0,77
-129,"n-octane__2,2,4-trimethylpentane",77,0,0,0,0,0,0,77
-130,ethanol__n-octane,77,0,0,0,0,0,0,77
-131,1-butanol__n-octane,77,0,0,0,0,0,0,77
-132,1-pentanol__n-octane,77,0,0,0,0,0,0,77
-133,1-octanol__1-nonanol,77,0,0,0,0,0,0,77
-134,"n-heptane__2,2,4-trimethylpentane",77,0,0,0,0,0,0,77
-135,"4-methylphenol__1,2-ethanediol",77,0,0,0,0,0,0,77
-136,1-propanol__n-octane,77,0,0,0,0,0,0,77
-600,ethanol__2-propanol,0,0,0,0,76,0,0,76
-139,"1,5-hexanediol__water",75,0,0,0,0,0,0,75
-601,ethanol__1-propanol,0,0,0,0,74,0,0,74
-144,1-butanol__2-methyl-2-propanol,72,0,0,0,0,0,0,72
-282,o-xylene__tetrahydropyran,36,0,36,0,0,0,0,72
-151,tert-butanol__heptane,70,0,0,0,0,0,0,70
-566,1-butanol__tetrahydropyran,0,0,35,0,33,0,0,68
-288,"2,5,8-trioxanonane__heptane",34,0,0,33,0,0,0,67
-155,"1,2-dihydroxypropane__amylcarbinol",66,0,0,0,0,0,0,66
-158,"1,2-dihydroxypropane__methyl alcohol",66,0,0,0,0,0,0,66
-162,"1,4-dimethylbenzene__heptane",66,0,0,0,0,0,0,66
-164,butylcyclohexane__JP-10,66,0,0,0,0,0,0,66
-166,"1,2-dihydroxypropane__1-nonanol",66,0,0,0,0,0,0,66
-167,"1,2,4-trimethylcyclohexane__JP-10",66,0,0,0,0,0,0,66
-168,methylcyclohexane__JP-10,66,0,0,0,0,0,0,66
-169,ethylcyclohexane__JP-10,66,0,0,0,0,0,0,66
-170,"1,2-dihydroxypropane__1-octanol",66,0,0,0,0,0,0,66
-262,toluene__hexane,39,0,11,0,16,0,0,66
-173,"1,3,5-trimethylbenzene__octane",64,0,0,0,0,0,0,64
-174,methanol__cyclohexane,64,0,0,0,0,0,0,64
-175,"1,3-dimethylbenzene__octane",64,0,0,0,0,0,0,64
-307,dimethylglycol__heptane,33,0,0,31,0,0,0,64
-311,3-methylphenol__1-nonanol,32,0,32,0,0,0,0,64
-312,2-methylphenol__1-nonanol,32,0,32,0,0,0,0,64
-313,methyl phenyl ether__1-nonanol,32,0,32,0,0,0,0,64
-314,4-methylphenol__1-nonanol,32,0,32,0,0,0,0,64
-178,ethanol__2-methyl-2-propanol,63,0,0,0,0,0,0,63
-180,2-phenylethanol__benzyl alcohol,63,0,0,0,0,0,0,63
-181,"2,2,4-trimethylpentane__1,3-dioxolane",63,0,0,0,0,0,0,63
-182,2-propanol__benzyl alcohol,63,0,0,0,0,0,0,63
-183,"2-methyl-2-propanol__2,2,4-trimethylpentane",63,0,0,0,0,0,0,63
-221,ethylbenzene__cyclooctane,48,0,13,0,0,0,0,61
-234,toluene__cyclooctane,48,0,13,0,0,0,0,61
-239,benzene__cyclooctane,48,0,13,0,0,0,0,61
-602,"(RS)-2-butanol__1,1-dimethylethyl methyl ether",0,0,0,0,61,0,0,61
-187,"1,2-dihydroxypropane__n-propyl alcohol",60,0,0,0,0,0,0,60
-188,ethanol__n-decane,60,0,0,0,0,0,0,60
-319,"furfuryl alcohol, tetrahydro-__water",30,0,30,0,0,0,0,60
-583,cyclohexane__tetrahydropyran,0,0,13,0,32,0,14,59
-603,"ethanol, 2-ethoxy-__octane",0,0,0,0,59,0,0,59
-260,benzene__heptane,40,0,18,0,0,0,0,58
-604,"ethanol, 2-ethoxy-__cyclohexane",0,0,0,0,58,0,0,58
-243,toluene__heptane,45,0,12,0,0,0,0,57
-605,1-butanol__5-oxanonane,0,0,0,0,57,0,0,57
-194,n-propanol__water,56,0,0,0,0,0,0,56
-196,"1-hexanol__1,4-dioxane",56,0,0,0,0,0,0,56
-198,"1,4-dimethylbenzene__pentylcarbinol",55,0,0,0,0,0,0,55
-201,methanol__3-methylphenol,55,0,0,0,0,0,0,55
-202,2-propanol__1-propanol,55,0,0,0,0,0,0,55
-204,1-octanol__heptane,55,0,0,0,0,0,0,55
-206,cyclohexane__JP-10,55,0,0,0,0,0,0,55
-207,methanol__4-methylphenol,55,0,0,0,0,0,0,55
-208,"pentyl alcohol__1,2-dimethoxyethane",54,0,0,0,0,0,0,54
-324,"1,3-dimethylbenzene__cyclooctane",27,0,27,0,0,0,0,54
-310,1-propanol__isopropyl ether,32,0,21,0,0,0,0,53
-325,"1,2-dimethylbenzene__methylcyclohexane",26,0,26,0,0,0,0,52
-326,"1,3-dimethylbenzene__methylcyclohexane",26,0,26,0,0,0,0,52
-327,"1,4-dimethylbenzene__cyclopentane",26,0,26,0,0,0,0,52
-328,"1,2-dimethylbenzene__cyclohexane",26,0,26,0,0,0,0,52
-329,"1,3-dimethylbenzene__cyclopentane",26,0,26,0,0,0,0,52
-330,"1,2-dimethylbenzene__cyclooctane",26,0,26,0,0,0,0,52
-331,"1,3,5-trimethylbenzene__cyclopentane",26,0,26,0,0,0,0,52
-332,"1,3,5-trimethylbenzene__cyclohexane",26,0,26,0,0,0,0,52
-334,"1,3,5-trimethylbenzene__cyclooctane",26,0,26,0,0,0,0,52
-336,"1,3-dimethylbenzene__cyclohexane",26,0,26,0,0,0,0,52
-337,"1,4-dimethylbenzene__cyclooctane",26,0,26,0,0,0,0,52
-338,"1,2-dimethylbenzene__cyclopentane",26,0,26,0,0,0,0,52
-568,"cyclohexane__1,4-dioxane",0,0,33,0,19,0,0,52
-606,"hexane__ethanol, 2-ethoxy-",0,0,0,0,51,0,0,51
-607,1-pentanol__cyclohexane,0,0,0,0,51,0,0,51
-210,"1,2-ethanediol__1-hexanol",50,0,0,0,0,0,0,50
-211,"1-butanol__1,2-ethanediol",50,0,0,0,0,0,0,50
-212,"1,2-ethanediol__1-octanol",50,0,0,0,0,0,0,50
-219,bis(2-hydroxyethyl) ether__butylmethylcarbinol,48,0,0,0,0,0,0,48
-220,"benzene__butane, 2-methoxy-2-methyl-",48,0,0,0,0,0,0,48
-222,sec-propyl alcohol__bis(2-hydroxyethyl) ether,48,0,0,0,0,0,0,48
-227,"2,2,4-trimethylpentane__butane, 2-methoxy-2-methyl-",48,0,0,0,0,0,0,48
-231,butan-2-ol__bis(2-hydroxyethyl) ether,48,0,0,0,0,0,0,48
-237,bis(2-hydroxyethyl) ether__amylmethylcarbinol,48,0,0,0,0,0,0,48
-238,bis(2-hydroxyethyl) ether__pentan-2-ol,48,0,0,0,0,0,0,48
-283,methylcyclohexane__1-heptanol,36,0,12,0,0,0,0,48
-286,benzene__nonane,35,0,13,0,0,0,0,48
-344,2-hydroxymethylfuran__water,24,0,24,0,0,0,0,48
-287,ethylbenzene__heptane,34,0,12,0,0,0,0,46
-240,1-hexanol__heptane,45,0,0,0,0,0,0,45
-242,isopropanol__isobutyl alcohol,45,0,0,0,0,0,0,45
-244,"ethanol__1,2-dimethoxyethane",45,0,0,0,0,0,0,45
-597,pentan-1-ol__n-octane,0,0,0,45,0,0,0,45
-598,n-octane__butyl oxide,0,0,0,45,0,0,0,45
-599,pentan-1-ol__butyl oxide,0,0,0,45,0,0,0,45
-247,"1,2-dimethoxyethane__1-octanol",44,0,0,0,0,0,0,44
-248,n-propyl alcohol__isobutyl alcohol,44,0,0,0,0,0,0,44
-290,"2-butoxyethanol__1-butanol, 3-methyl-",33,0,11,0,0,0,0,44
-291,1-propanol__methylcyclohexane,33,0,11,0,0,0,0,44
-292,1-butanol__methoxybenzene,33,0,11,0,0,0,0,44
-294,methoxybenzene__methylcyclohexane,33,0,11,0,0,0,0,44
-295,1-pentanol__methoxybenzene,33,0,11,0,0,0,0,44
-296,2-methyl-1-propanol__methylcyclohexane,33,0,11,0,0,0,0,44
-297,methylcyclohexane__3-methyl-1-butanol,33,0,11,0,0,0,0,44
-298,2-propanol__methoxybenzene,33,0,11,0,0,0,0,44
-299,2-propanol__methylcyclohexane,33,0,11,0,0,0,0,44
-300,1-propanol__methoxybenzene,33,0,11,0,0,0,0,44
-301,ethanol__methoxybenzene,33,0,11,0,0,0,0,44
-306,methoxybenzene__3-methyl-1-butanol,33,0,11,0,0,0,0,44
-346,ethanol__isopropyl ether,24,0,0,0,19,0,0,43
-249,"1,3,5-trimethylbenzene__2-methoxyethanol",42,0,0,0,0,0,0,42
-250,"1,4-dimethylbenzene__hexane",42,0,0,0,0,0,0,42
-251,"1,3,5-trimethylbenzene__1,2-dimethoxyethane",42,0,0,0,0,0,0,42
-253,"1,2,4-trimethylbenzene__1,2-dimethoxyethane",42,0,0,0,0,0,0,42
-254,"1,2,4-trimethylbenzene__2-methoxyethanol",42,0,0,0,0,0,0,42
-256,toluene__1-octanol,42,0,0,0,0,0,0,42
-258,toluene__1-heptanol,42,0,0,0,0,0,0,42
-371,ethylene glycol methyl ether__water,21,0,21,0,0,0,0,42
-372,1-propanol__tert-amyl methyl ether,21,0,21,0,0,0,0,42
-373,1-propanol__methyl tert-butyl ether,21,0,21,0,0,0,0,42
-408,"isopropyl ether__2,2,4-trimethylpentane",13,0,10,0,19,0,0,42
-577,"1,2-dimethylbenzene__tetrahydropyran",0,0,14,0,14,0,14,42
-578,n-hexane__tetrahydropyran,0,0,14,0,14,0,14,42
-579,"1,3-dimethylbenzene__tetrahydropyran",0,0,14,0,14,0,14,42
-580,tetrahydropyran__heptane,0,0,14,0,14,0,14,42
-581,"1,4-dimethylbenzene__tetrahydropyran",0,0,14,0,14,0,14,42
-608,n-heptane__2-pentanol,0,0,0,0,42,0,0,42
-609,pentan-1-ol__isooctane,0,0,0,0,42,0,0,42
-610,1-pentanol__toluene,0,0,0,0,42,0,0,42
-611,pentan-1-ol__heptane,0,0,0,0,42,0,0,42
-612,"2,2,4-trimethylpentane__2-pentanol",0,0,0,0,42,0,0,42
-259,xyliton__water,40,0,0,0,0,0,0,40
-349,"3,6-dioxa-1-octanol__water",24,0,16,0,0,0,0,40
-270,cyclohexane__2-pentanol,39,0,0,0,0,0,0,39
-278,cyclohexane__heptane,39,0,0,0,0,0,0,39
-613,"2-methyl-2-butanol__1,1-dimethylethyl methyl ether",0,0,0,0,39,0,0,39
-377,1-propanol__2-methyl-1-butanol,19,0,19,0,0,0,0,38
-378,1-propanol__3-methyl-1-butanol,19,0,19,0,0,0,0,38
-379,methanol__2-methyl-1-butanol,19,0,19,0,0,0,0,38
-383,"hexane__ether, methyl tert-pentyl",19,0,0,0,0,0,19,38
-614,"5-oxanonane__2,2,4-trimethylpentane",0,0,0,0,38,0,0,38
-615,heptane__dibutyl ether,0,0,0,0,38,0,0,38
-616,methylcyclohexane__5-oxanonane,0,0,0,0,38,0,0,38
-617,toluene__5-oxanonane,0,0,0,0,38,0,0,38
-280,octane__heptane,37,0,0,0,0,0,0,37
-350,ethylbenzene__hexane,24,0,13,0,0,0,0,37
-285,"1,2-dimethylbenzene__1,2-dimethoxyethane",36,0,0,0,0,0,0,36
-335,1-pentanol__cyclopentane,26,0,0,0,10,0,0,36
-386,water__dipropylene glycol monomethyl ether,18,0,18,0,0,0,0,36
-387,2-isopropoxyethanol__water,18,0,18,0,0,0,0,36
-618,"benzene__ethanol, 2-ethoxy-",0,0,0,0,36,0,0,36
-342,1-heptanol__cyclopentane,24,0,0,0,11,0,0,35
-351,toluene__nonane,23,0,12,0,0,0,0,35
-619,ethanol__benzene,0,0,0,0,35,0,0,35
-289,"methoxybenzene__1,4-dioxane",33,0,0,0,0,0,0,33
-293,"1,2-propanediol__1,2-ethanediol",33,0,0,0,0,0,0,33
-302,"1,2-propanediol__1,3-propanediol",33,0,0,0,0,0,0,33
-303,"1,4-dimethylbenzene__1,2-dimethoxyethane",33,0,0,0,0,0,0,33
-304,methylcyclohexane__exo-tetrahydrodicyclopentadiene,33,0,0,0,0,0,0,33
-308,"1,2-propanediol__pentylcarbinol",33,0,0,0,0,0,0,33
-309,"1,2-ethanediol__1,3-propanediol",33,0,0,0,0,0,0,33
-567,"1,4-dioxane__cyclopentane",0,0,33,0,0,0,0,33
-569,"benzene__1,4-dioxane",0,0,33,0,0,0,0,33
-389,2-methyl-1-propanol__hexane,16,0,16,0,0,0,0,32
-390,2-methyl-1-propanol__decane,16,0,16,0,0,0,0,32
-391,2-methyl-1-propanol__octane,16,0,16,0,0,0,0,32
-315,"1,3-dimethylbenzene__hexane",31,0,0,0,0,0,0,31
-316,xylitol__water,30,0,0,0,0,0,0,30
-317,propan-1-ol__water,30,0,0,0,0,0,0,30
-318,"1,2-propanediol__1-heptanol",30,0,0,0,0,0,0,30
-399,2-phenylethanol__ethoxybenzene,13,0,0,0,17,0,0,30
-570,benzyl alcohol__1-octanol,0,0,30,0,0,0,0,30
-571,benzyl alcohol__1-heptanol,0,0,30,0,0,0,0,30
-572,benzyl alcohol__1-nonanol,0,0,30,0,0,0,0,30
-620,benzene__5-oxanonane,0,0,0,0,30,0,0,30
-402,cyclohexane__octane,13,0,0,0,16,0,0,29
-412,benzyl alcohol__ethoxybenzene,12,0,0,0,17,0,0,29
-417,benzyl alcohol__methoxybenzene,12,0,0,0,17,0,0,29
-419,2-phenylethanol__methoxybenzene,12,0,0,0,17,0,0,29
-420,ethoxybenzene__3-phenyl-1-propanol,12,0,0,0,17,0,0,29
-422,methoxybenzene__3-phenyl-1-propanol,12,0,0,0,17,0,0,29
-393,"1,2-butanediol__water",14,0,0,0,0,0,14,28
-394,trimethylene glycol__water,14,0,0,0,0,0,14,28
-395,"2,3-butanediol__water",14,0,0,0,0,0,14,28
-396,"butane, 1,4-dihydroxy-__water",14,0,0,0,0,0,14,28
-397,"1,3-butanediol__water",14,0,0,0,0,0,14,28
-418,"ethanol, 2-ethoxy-__water",12,0,16,0,0,0,0,28
-440,"1,4-dioxane__water",10,0,18,0,0,0,0,28
-321,tetrole__n-hexane,27,0,0,0,0,0,0,27
-322,"1,2-dimethylbenzene__hexane",27,0,0,0,0,0,0,27
-323,phenylmethane__tetrole,27,0,0,0,0,0,0,27
-573,"benzene__1,3-dioxolane",0,0,27,0,0,0,0,27
-574,"cyclopentane__1,3-dioxolane",0,0,27,0,0,0,0,27
-575,"cyclohexane__1,3-dioxolane",0,0,27,0,0,0,0,27
-400,ethylbenzene__octane,13,0,13,0,0,0,0,26
-403,toluene__cyclopentane,13,0,13,0,0,0,0,26
-406,ethylbenzene__cyclopentane,13,0,13,0,0,0,0,26
-407,ethylbenzene__nonane,13,0,13,0,0,0,0,26
-410,benzene__cyclopentane,13,0,13,0,0,0,0,26
-339,n-propyl alcohol__water,25,0,0,0,0,0,0,25
-340,"propan-1-ol__1,3-benzenediol",25,0,0,0,0,0,0,25
-341,"butan-1-ol__1,3-benzenediol",25,0,0,0,0,0,0,25
-374,glycerol__ethanol,20,5,0,0,0,0,0,25
-404,ethylene glycol__1-heptanol,13,0,12,0,0,0,0,25
-343,methanol__toluene,24,0,0,0,0,0,0,24
-345,2-ethoxyethanol__water,24,0,0,0,0,0,0,24
-347,2-n-butoxyethanol__water,24,0,0,0,0,0,0,24
-348,D-(+)-arabitol__water,24,0,0,0,0,0,0,24
-413,isobutanol__water,12,0,12,0,0,0,0,24
-414,benzene__hexane,12,0,12,0,0,0,0,24
-424,"ethane, 1,1'-oxybis-__1,3-dioxolane",11,0,12,0,0,0,0,23
-621,neohexane__tetrahydrofuran,0,0,0,0,23,0,0,23
-622,diisopropyl__tetrahydrofuran,0,0,0,0,23,0,0,23
-352,ethylene glycol__1-nonanol,22,0,0,0,0,0,0,22
-353,benzene__methoxybenzene,22,0,0,0,0,0,0,22
-355,methoxybenzene__butylbenzene,22,0,0,0,0,0,0,22
-356,benzene__toluene,22,0,0,0,0,0,0,22
-357,"1,3-dimethylbenzene__pentylcarbinol",22,0,0,0,0,0,0,22
-358,methoxybenzene__toluene,22,0,0,0,0,0,0,22
-359,benzene__ethylbenzene,22,0,0,0,0,0,0,22
-360,heptane__cyclooctane,22,0,0,0,0,0,0,22
-361,ethylbenzene__methoxybenzene,22,0,0,0,0,0,0,22
-362,1-propanol__1-heptanol,22,0,0,0,0,0,0,22
-363,"1,2-dimethylbenzene__pentylcarbinol",22,0,0,0,0,0,0,22
-364,methoxybenzene__propylbenzene,22,0,0,0,0,0,0,22
-365,1-heptanol__1-nonanol,22,0,0,0,0,0,0,22
-366,ethylbenzene__toluene,22,0,0,0,0,0,0,22
-367,1-propanol__1-pentanol,22,0,0,0,0,0,0,22
-368,1-propanol__1-nonanol,22,0,0,0,0,0,0,22
-369,1-pentanol__1-nonanol,22,0,0,0,0,0,0,22
-370,1-pentanol__1-heptanol,22,0,0,0,0,0,0,22
-416,2-ethyl-1-hexanol__ethylene glycol,12,0,10,0,0,0,0,22
-425,"ethane, 1,1'-oxybis-__pentan-1-ol",11,0,11,0,0,0,0,22
-426,"2-methoxyethanol__1,3-dioxolane",11,0,11,0,0,0,0,22
-431,"pentan-1-ol__1,3-dioxolane",11,0,11,0,0,0,0,22
-432,"ethanol, 2-ethoxy-__1,3-dioxolane",11,0,11,0,0,0,0,22
-433,"2-butoxyethanol__1,3-dioxolane",11,0,11,0,0,0,0,22
-584,benzene__2-methyltetrahydrofuran,0,0,11,0,11,0,0,22
-434,isopropyl ether__toluene,11,0,0,0,10,0,0,21
-623,tetramethylene oxide__dibutyl ether,0,0,0,0,21,0,0,21
-375,"ethanol__1,3-benzenediol",20,0,0,0,0,0,0,20
-438,ethanol__ethylene glycol,10,0,10,0,0,0,0,20
-624,"2,3-dimethylbutane__ether, dipropyl",0,0,0,0,20,0,0,20
-625,"butane, 2,2-dimethyl-__butyl oxide",0,0,0,0,20,0,0,20
-626,dipropyl ether__dibutyl ether,0,0,0,0,20,0,0,20
-627,tetramethylene oxide__dipropyl ether,0,0,0,0,20,0,0,20
-628,"2,3-dimethylbutane__butyl oxide",0,0,0,0,20,0,0,20
-629,methanol__dibutyl ether,0,0,0,0,20,0,0,20
-376,2-methyl-1-propanol__2-methyl-1-butanol,19,0,0,0,0,0,0,19
-380,2-methyl-1-propanol__3-methyl-1-butanol,19,0,0,0,0,0,0,19
-381,1-propanol__tert-butyl ethyl ether,19,0,0,0,0,0,0,19
-382,1-pentanol__2-methyl-1-propanol,19,0,0,0,0,0,0,19
-630,1-methoxy-2-propanol__cyclohexane,0,0,0,0,19,0,0,19
-631,"butane, 2,2-dimethyl-__ether, dipropyl",0,0,0,0,19,0,0,19
-632,cyclohexane__2-butoxyethanol,0,0,0,0,19,0,0,19
-633,1-pentanol__decane,0,0,0,0,19,0,0,19
-634,methanol__methoxymethane,0,0,0,0,19,0,0,19
-635,cyclohexane__5-oxanonane,0,0,0,0,19,0,0,19
-636,epoxypropane__2-methylpentane,0,0,0,0,19,0,0,19
-637,1-propanol__methoxymethane,0,0,0,0,19,0,0,19
-638,"octane__1,4-dioxane",0,0,0,0,19,0,0,19
-639,ethanol__methoxymethane,0,0,0,0,19,0,0,19
-640,1-butanol__methoxymethane,0,0,0,0,19,0,0,19
-641,cyclohexane__dibutyl ether,0,0,0,0,19,0,0,19
-642,benzene__1-methoxy-2-propanol,0,0,0,0,19,0,0,19
-643,benzene__2-butoxyethanol,0,0,0,0,19,0,0,19
-644,ethanol__tetrahydropyran,0,0,0,0,19,0,0,19
-384,ethane__toluene,18,0,0,0,0,0,0,18
-385,"n-hexane__2,5-dimethylfuran",18,0,0,0,0,0,0,18
-446,2-methyl-2-butanol__ethyl tert-pentyl ether,9,0,0,0,9,0,0,18
-448,butan-2-ol__ethyl tert-pentyl ether,9,0,0,0,9,0,0,18
-450,1-butanol__ethyl tert-pentyl ether,9,0,0,0,9,0,0,18
-645,hexane__cyclohexane,0,0,0,0,18,0,0,18
-646,1-pentanol__nonane,0,0,0,0,18,0,0,18
-647,1-pentanol__hexane,0,0,0,0,18,0,0,18
-648,"benzyl alcohol__3,6-dioxa-1-octanol",0,0,0,0,17,0,0,17
-649,benzyl alcohol__dibutyl ether,0,0,0,0,17,0,0,17
-650,"benzyl alcohol__1,2-dimethoxyethane",0,0,0,0,17,0,0,17
-651,"benzyl alcohol__ethanol, 2-ethoxy-",0,0,0,0,17,0,0,17
-652,1-propanol__decane,0,0,0,0,17,0,0,17
-653,2-methyl-1-propanol__1-methyl-1-(1-methylethoxy)ethane,0,0,0,0,17,0,0,17
-654,"benzyl alcohol__3,6-dioxaoctane",0,0,0,0,17,0,0,17
-388,methanol__dioxane,16,0,0,0,0,0,0,16
-466,tert-pentyl alcohol__water,0,16,0,0,0,0,0,16
-576,2-methoxyethanol__water,0,0,16,0,0,0,0,16
-655,1-propanol__heptane,0,0,0,0,16,0,0,16
-392,methane__pentane,15,0,0,0,0,0,0,15
-467,"1-butanol, 3-methyl-__water",0,15,0,0,0,0,0,15
-468,2-methyl-1-butanol__water,0,15,0,0,0,0,0,15
-656,ethanol__nonane,0,0,0,0,15,0,0,15
-657,ethanol__decane,0,0,0,0,15,0,0,15
-658,butan-2-ol__cyclohexyl alcohol,0,0,0,0,15,0,0,15
-659,1-propanol__nonane,0,0,0,0,15,0,0,15
-660,"1,2-dimethylbenzene__dibutyl ether",0,0,0,0,15,0,0,15
-398,2-ethyl-1-hexanol__1-nonanol,14,0,0,0,0,0,0,14
-661,benzene__2-methyl-1-propanol,0,0,0,0,14,0,0,14
-401,ethanol__oxane,13,0,0,0,0,0,0,13
-405,1-octanol__2-octanol,13,0,0,0,0,0,0,13
-409,anisole__phenol,13,0,0,0,0,0,0,13
-411,2-ethyl-1-hexanol__1-heptanol,13,0,0,0,0,0,0,13
-469,pentan-2-ol__water,0,13,0,0,0,0,0,13
-582,"1-butanol__1,2-butanediol",0,0,13,0,0,0,0,13
-662,1-butanol__1-methyl-1-(1-methylethoxy)ethane,0,0,0,0,13,0,0,13
-663,n-butyl alcohol__cyclohexyl alcohol,0,0,0,0,13,0,0,13
-415,"1,3-dioxolane__water",12,0,0,0,0,0,0,12
-421,2-propanol__methane,12,0,0,0,0,0,0,12
-423,methanol__tetrahydrofuran,12,0,0,0,0,0,0,12
-664,1-methyl-1-(1-methylethoxy)ethane__heptane,0,0,0,0,12,0,0,12
-427,benzene__2-methoxyethanol,11,0,0,0,0,0,0,11
-428,benzene__methyl tert-butyl ether,11,0,0,0,0,0,0,11
-429,benzene__dibutyl ether,11,0,0,0,0,0,0,11
-430,methanol__anisol,11,0,0,0,0,0,0,11
-435,toluene__2-methoxyethanol,11,0,0,0,0,0,0,11
-436,p-xylene__2-methoxyethanol,11,0,0,0,0,0,0,11
-437,ethanol__dibutyl ether,11,0,0,0,0,0,0,11
-470,3-pentanol__water,0,11,0,0,0,0,0,11
-665,"1,2-propanediol__methanol",0,0,0,0,11,0,0,11
-666,propyl alcohol__cyclohexyl alcohol,0,0,0,0,11,0,0,11
-667,methanol__.alpha.-toluenol,0,0,0,0,11,0,0,11
-668,tetrahydrofuran__nonane,0,0,0,0,11,0,0,11
-669,1-hexanol__cyclopentane,0,0,0,0,11,0,0,11
-670,"isopropyl ether__1,3-dimethylbenzene",0,0,0,0,11,0,0,11
-439,1-pentanol__2-ethyl-1-hexanol,10,0,0,0,0,0,0,10
-441,phenol__1-octanol,10,0,0,0,0,0,0,10
-442,"2-ethyl-1-hexanol__2,3-butanediol",10,0,0,0,0,0,0,10
-443,2-propanol__ethane,10,0,0,0,0,0,0,10
-461,naphthalene__heptane,5,0,5,0,0,0,0,10
-462,naphthalene__cyclohexane,5,0,5,0,0,0,0,10
-471,3-methyl-2-butanol__water,0,10,0,0,0,0,0,10
-585,isopropyl ether__hexane,0,0,10,0,0,0,0,10
-586,isopropyl ether__heptane,0,0,10,0,0,0,0,10
-587,isopropyl ether__octane,0,0,10,0,0,0,0,10
-671,"1,2-propanediol__1-hexanol",0,0,0,0,10,0,0,10
-672,pentan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10
-673,ethanol__cyclohexyl alcohol,0,0,0,0,10,0,0,10
-674,ethanol__.alpha.-toluenol,0,0,0,0,10,0,0,10
-675,1-nonanol__cyclopentane,0,0,0,0,10,0,0,10
-676,ethanol__tert-pentyl alcohol,0,0,0,0,10,0,0,10
-677,butan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10
-678,"1,2-propanediol__1-pentanol",0,0,0,0,10,0,0,10
-679,"1,2-propanediol__ethanol",0,0,0,0,10,0,0,10
-680,"1,2-propanediol__1-butanol",0,0,0,0,10,0,0,10
-681,1-octanol__cyclopentane,0,0,0,0,10,0,0,10
-682,cyclohexane__1-heptanol,0,0,0,0,10,0,0,10
-683,propan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10
-684,methanol__cyclohexyl alcohol,0,0,0,0,10,0,0,10
-685,"1,2-propanediol__1-propanol",0,0,0,0,10,0,0,10
-686,methanol__tert-pentyl alcohol,0,0,0,0,10,0,0,10
-444,ethane__pentane,9,0,0,0,0,0,0,9
-445,(RS)-2-butanol__water,9,0,0,0,0,0,0,9
-447,"2-ethyl-1-hexanol__butane, 1,4-dihydroxy-",9,0,0,0,0,0,0,9
-449,cyclohexane__1-octanol,9,0,0,0,0,0,0,9
-451,isooctane__methyl tert-butyl ether,9,0,0,0,0,0,0,9
-472,furan__water,0,9,0,0,0,0,0,9
-588,isopropyl ether__cyclohexane,0,0,9,0,0,0,0,9
-589,isopropyl ether__tetralin,0,0,9,0,0,0,0,9
-590,benzene__isopropyl ether,0,0,9,0,0,0,0,9
-591,decahydronaphthalene__isopropyl ether,0,0,9,0,0,0,0,9
-687,propan-1-ol__.alpha.-toluenol,0,0,0,0,9,0,0,9
-688,1-pentanol__tetrahydropyran,0,0,0,0,9,0,0,9
-689,butan-1-ol__.alpha.-toluenol,0,0,0,0,9,0,0,9
-690,tetrahydropyran__decane,0,0,0,0,9,0,0,9
-691,"1,4-dioxane__tetrahydropyran",0,0,0,0,9,0,0,9
-692,.alpha.-toluenol__pentylcarbinol,0,0,0,0,9,0,0,9
-693,cyclohexane__1-nonanol,0,0,0,0,9,0,0,9
-694,2-propanol__cyclohexyl alcohol,0,0,0,0,9,0,0,9
-695,pentan-1-ol__.alpha.-toluenol,0,0,0,0,9,0,0,9
-696,tetrahydropyran__1-nonanol,0,0,0,0,9,0,0,9
-452,"3-oxa-1,5-pentanediol__3,6-dioxa-1,8-octanediol",8,0,0,0,0,0,0,8
-453,isopropyl ether__isooctane,8,0,0,0,0,0,0,8
-454,"1,2-ethanediol__3-oxa-1,5-pentanediol",8,0,0,0,0,0,0,8
-455,ethylene glycol__bis(2-hydroxyethyl) ether,8,0,0,0,0,0,0,8
-456,"1,2-ethanediol__3,6-dioxa-1,8-octanediol",8,0,0,0,0,0,0,8
-457,methane__butane,6,0,0,0,0,0,0,6
-458,"bis(2-hydroxyethyl) ether__3,6-dioxa-1,8-octanediol",5,0,0,0,0,0,0,5
-459,"ethylene glycol__3,6-dioxa-1,8-octanediol",5,0,0,0,0,0,0,5
-460,methanol__2-methoxyethanol,5,0,0,0,0,0,0,5
-473,toluene__methoxymethane,0,5,0,0,0,0,0,5
-474,"1,4-dimethylbenzene__butane",0,5,0,0,0,0,0,5
-475,"decane__1,3-propanediol",0,5,0,0,0,0,0,5
-476,"propane__1,4-dimethylbenzene",0,5,0,0,0,0,0,5
-477,"1,2-dimethylbenzene__methoxymethane",0,5,0,0,0,0,0,5
-478,"octane__1,3-propanediol",0,5,0,0,0,0,0,5
-479,"2-methylpropane__1,4-dimethylbenzene",0,5,0,0,0,0,0,5
-480,"1,4-dimethylbenzene__methoxymethane",0,5,0,0,0,0,0,5
-463,methane__ethane,4,0,0,0,0,0,0,4
-481,2-methylpropane__toluene,0,4,0,0,0,0,0,4
-482,"butane, 2-ethoxy-2-methyl-__water",0,4,0,0,0,0,0,4
-483,"2-methylpropane__1,2-dimethylbenzene",0,4,0,0,0,0,0,4
-484,benzene__methoxymethane,0,4,0,0,0,0,0,4
-485,"propane__1,2-dimethylbenzene",0,4,0,0,0,0,0,4
-486,butane__toluene,0,4,0,0,0,0,0,4
-487,benzene__propane,0,4,0,0,0,0,0,4
-488,"2-methylpropane__1,3-dimethylbenzene",0,4,0,0,0,0,0,4
-489,"1,3-dimethylbenzene__methoxymethane",0,4,0,0,0,0,0,4
-490,toluene__water,0,4,0,0,0,0,0,4
-491,methyl tert-butyl ether__water,0,4,0,0,0,0,0,4
-492,"propane__1,3-dimethylbenzene",0,4,0,0,0,0,0,4
-493,"1,2-dimethylbenzene__butane",0,4,0,0,0,0,0,4
-494,tert-amyl methyl ether__water,0,4,0,0,0,0,0,4
-495,benzene__2-methylpropane,0,4,0,0,0,0,0,4
-496,tert-butyl ethyl ether__water,0,4,0,0,0,0,0,4
-497,propane__toluene,0,4,0,0,0,0,0,4
-498,benzene__butane,0,4,0,0,0,0,0,4
-499,"butane__1,3-dimethylbenzene",0,4,0,0,0,0,0,4
-464,methanol__ethane,3,0,0,0,0,0,0,3
-500,diethylene glycol__n-nonane,0,3,0,0,0,0,0,3
-501,triethylene glycol__n-heptane,0,3,0,0,0,0,0,3
-502,n-octane__triethylene glycol,0,3,0,0,0,0,0,3
-503,n-nonane__triethylene glycol,0,3,0,0,0,0,0,3
-504,triethylene glycol__cycloheptane,0,3,0,0,0,0,0,3
-505,2-propanol__triethylene glycol,0,3,0,0,0,0,0,3
-506,ethanol__triethylene glycol,0,3,0,0,0,0,0,3
-507,diethylene glycol__cycloheptane,0,3,0,0,0,0,0,3
-508,n-hexane__diethylene glycol,0,3,0,0,0,0,0,3
-509,diethylene glycol__cyclopentane,0,3,0,0,0,0,0,3
-510,cyclohexane__diethylene glycol,0,3,0,0,0,0,0,3
-511,cyclohexane__triethylene glycol,0,3,0,0,0,0,0,3
-512,2-propanol__diethylene glycol,0,3,0,0,0,0,0,3
-513,benzene__triethylene glycol,0,3,0,0,0,0,0,3
-514,ethylbenzene__triethylene glycol,0,3,0,0,0,0,0,3
-515,ethylbenzene__diethylene glycol,0,3,0,0,0,0,0,3
-516,1-propanol__triethylene glycol,0,3,0,0,0,0,0,3
-517,diethylene glycol__cyclooctane,0,3,0,0,0,0,0,3
-518,toluene__diethylene glycol,0,3,0,0,0,0,0,3
-519,n-pentane__triethylene glycol,0,3,0,0,0,0,0,3
-520,diethylene glycol__n-heptane,0,3,0,0,0,0,0,3
-521,"hexane__1,3-propanediol",0,3,0,0,0,0,0,3
-522,n-pentane__diethylene glycol,0,3,0,0,0,0,0,3
-523,methanol__diethylene glycol,0,3,0,0,0,0,0,3
-524,1-propanol__diethylene glycol,0,3,0,0,0,0,0,3
-525,triethylene glycol__cyclooctane,0,3,0,0,0,0,0,3
-526,n-hexane__triethylene glycol,0,3,0,0,0,0,0,3
-527,triethylene glycol__cyclopentane,0,3,0,0,0,0,0,3
-528,"1,2-ethanediol__hexane",0,3,0,0,0,0,0,3
-529,toluene__triethylene glycol,0,3,0,0,0,0,0,3
-530,diethylene glycol__n-octane,0,3,0,0,0,0,0,3
-531,"1,2-ethanediol__decane",0,3,0,0,0,0,0,3
-532,ethanol__diethylene glycol,0,3,0,0,0,0,0,3
-533,benzene__diethylene glycol,0,3,0,0,0,0,0,3
-534,methanol__triethylene glycol,0,2,0,0,0,0,0,2
-535,2-methylphenol__nonane,0,2,0,0,0,0,0,2
-536,3-methylphenol__nonane,0,2,0,0,0,0,0,2
-465,glycidol__water,1,0,0,0,0,0,0,1
-537,methyl cellosolve__n-decane,0,1,0,0,0,0,0,1
-538,methylcyclopentane__methyl cellosolve,0,1,0,0,0,0,0,1
-539,propylene glycol__n-octane,0,1,0,0,0,0,0,1
-540,methyl cellosolve__cyclohexane,0,1,0,0,0,0,0,1
-541,methyl cellosolve__cyclooctane,0,1,0,0,0,0,0,1
-542,2-methylphenol__decane,0,1,0,0,0,0,0,1
-543,methylcyclohexane__methyl cellosolve,0,1,0,0,0,0,0,1
-544,benzene__methyl cellosolve,0,1,0,0,0,0,0,1
-545,m-xylene__methyl cellosolve,0,1,0,0,0,0,0,1
-546,propylene glycol__toluene,0,1,0,0,0,0,0,1
-547,propylene glycol__benzene,0,1,0,0,0,0,0,1
-548,o-xylene__methyl cellosolve,0,1,0,0,0,0,0,1
-549,propylene glycol__ethylbenzene,0,1,0,0,0,0,0,1
-550,propylene glycol__m-xylene,0,1,0,0,0,0,0,1
-551,propylene glycol__naphthalene,0,1,0,0,0,0,0,1
-552,3-methylphenol__decane,0,1,0,0,0,0,0,1
-553,p-cymene__methyl cellosolve,0,1,0,0,0,0,0,1
-554,toluene__methyl cellosolve,0,1,0,0,0,0,0,1
-555,naphthalene__methyl cellosolve,0,1,0,0,0,0,0,1
-556,propylene glycol__n-heptane,0,1,0,0,0,0,0,1
-557,ethylbenzene__methyl cellosolve,0,1,0,0,0,0,0,1
-558,p-xylene__methyl cellosolve,0,1,0,0,0,0,0,1
-559,methyl cellosolve__n-heptane,0,1,0,0,0,0,0,1
-560,methyl cellosolve__n-hexane,0,1,0,0,0,0,0,1
-561,propylene glycol__n-hexane,0,1,0,0,0,0,0,1
-562,methyl cellosolve__n-nonane,0,1,0,0,0,0,0,1
-563,propylene glycol__o-xylene,0,1,0,0,0,0,0,1
-564,propylene glycol__p-xylene,0,1,0,0,0,0,0,1
-565,methyl cellosolve__n-octane,0,1,0,0,0,0,0,1
+,Mixture,Mixture Count dens binary,Mixture Count actcoeff binary,Mixture Count sos binary,Mixture Count dielec binary,Mixture Count eme binary,Mixture Count emcp binary,Mixture Count emv binary,Mixture Count all,x1,x2,SMILES1,SMILES2
+0,benzene__octane,1067,0,13,0,0,0,0,1080,benzene,octane,c1ccccc1,CCCCCCCC
+2,2-propanol__water,1012,0,0,0,45,0,0,1057,2-propanol,water,CC(C)O,O
+1,cyclohexane__nonane,1031,0,0,0,0,0,0,1031,cyclohexane,nonane,C1CCCCC1,CCCCCCCCC
+3,1-propanol__toluene,842,0,0,0,0,0,0,842,1-propanol,toluene,CCCO,Cc1ccccc1
+9,ethanol__water,712,0,20,0,83,0,0,815,ethanol,water,CCO,O
+8,ethanol__toluene,723,0,71,0,0,0,0,794,ethanol,toluene,CCO,Cc1ccccc1
+5,ethanol__methylcyclohexane,753,0,11,0,0,0,0,764,ethanol,methylcyclohexane,CCO,CC1CCCCC1
+4,1-heptanol__heptane,756,0,0,0,0,0,0,756,1-heptanol,heptane,CCCCCCCO,CCCCCCC
+6,n-octane__n-decane,750,0,0,0,0,0,0,750,n-octane,n-decane,CCCCCCCC,CCCCCCCCCC
+7,n-decane__heptane,750,0,0,0,0,0,0,750,n-decane,heptane,CCCCCCCCCC,CCCCCCC
+10,ethanol__heptane,708,0,39,0,0,0,0,747,ethanol,heptane,CCO,CCCCCCC
+11,2-methyl-2-propanol__water,636,0,6,0,0,0,0,642,2-methyl-2-propanol,water,CC(C)(C)O,O
+12,1-butanol__cyclohexane,501,0,51,0,38,0,0,590,1-butanol,cyclohexane,CCCCO,C1CCCCC1
+89,tert-pentyl alcohol__heptane,102,0,450,0,0,0,0,552,tert-pentyl alcohol,heptane,CCC(C)(C)O,CCCCCCC
+63,"1,4-butanediol__water",142,0,142,0,36,109,109,538,"1,4-butanediol",water,OCCCCO,O
+17,1-propoxy-2-propanol__water,318,0,145,0,0,0,0,463,1-propoxy-2-propanol,water,CCCOCC(C)O,O
+13,glycerol__water,381,5,0,8,0,0,0,394,glycerol,water,OCC(O)CO,O
+38,"1,2-dimethylbenzene__methyl tert-butyl ether",195,0,195,0,0,0,0,390,"1,2-dimethylbenzene",methyl tert-butyl ether,Cc1ccccc1C,COC(C)(C)C
+39,"1,3-dimethylbenzene__tert-butyl ethyl ether",195,0,195,0,0,0,0,390,"1,3-dimethylbenzene",tert-butyl ethyl ether,Cc1cccc(C)c1,CCOC(C)(C)C
+40,"1,3-dimethylbenzene__methyl tert-butyl ether",195,0,195,0,0,0,0,390,"1,3-dimethylbenzene",methyl tert-butyl ether,Cc1cccc(C)c1,COC(C)(C)C
+41,"1,2-dimethylbenzene__tert-butyl ethyl ether",195,0,195,0,0,0,0,390,"1,2-dimethylbenzene",tert-butyl ethyl ether,Cc1ccccc1C,CCOC(C)(C)C
+42,"1,4-dimethylbenzene__methyl tert-butyl ether",195,0,195,0,0,0,0,390,"1,4-dimethylbenzene",methyl tert-butyl ether,Cc1ccc(C)cc1,COC(C)(C)C
+43,"1,4-dimethylbenzene__tert-butyl ethyl ether",195,0,195,0,0,0,0,390,"1,4-dimethylbenzene",tert-butyl ethyl ether,Cc1ccc(C)cc1,CCOC(C)(C)C
+33,methanol__water,212,0,12,0,140,0,0,364,methanol,water,CO,O
+14,tert-butanol__water,360,0,0,0,0,0,0,360,tert-butanol,water,CC(C)(C)O,O
+27,1-hexanol__dibutyl ether,254,0,54,0,20,0,0,328,1-hexanol,dibutyl ether,CCCCCCO,CCCCOCCCC
+15,"1,1,1-trimethanolethane__water",324,0,0,0,0,0,0,324,"1,1,1-trimethanolethane",water,CC(CO)(CO)CO,O
+16,n-butyl alcohol__2-methylheptane,324,0,0,0,0,0,0,324,n-butyl alcohol,2-methylheptane,CCCCO,CCCCCC(C)C
+25,benzene__cyclohexane,262,0,44,0,0,0,0,306,benzene,cyclohexane,c1ccccc1,C1CCCCC1
+84,"1,3-propanediol__water",106,0,0,8,36,64,90,304,"1,3-propanediol",water,OCCCO,O
+18,n-butyl alcohol__butyl oxide,300,0,0,0,0,0,0,300,n-butyl alcohol,butyl oxide,CCCCO,CCCCOCCCC
+21,cyclohexanol__water,280,0,15,0,0,0,0,295,cyclohexanol,water,OC1CCCCC1,O
+19,cyclopentanol__water,287,0,0,0,0,0,0,287,cyclopentanol,water,OC1CCCC1,O
+20,bis(2-hydroxyethyl) ether__water,280,0,0,0,0,0,0,280,bis(2-hydroxyethyl) ether,water,OCCOCCO,O
+22,cis-decalin__trans-decalin,278,0,0,0,0,0,0,278,cis-decalin,trans-decalin,C1CC[C@@H]2CCCC[C@@H]2C1,C1CC[C@@H]2CCCC[C@H]2C1
+71,.beta.-butylene glycol__water,138,0,138,0,0,0,0,276,.beta.-butylene glycol,water,CC(O)CCO,O
+23,"2-ethyl-2-(hydroxymethyl)-1,3-propanediol__water",270,0,0,0,0,0,0,270,"2-ethyl-2-(hydroxymethyl)-1,3-propanediol",water,CCC(CO)(CO)CO,O
+24,"1,5-pentanediol__water",269,0,0,0,0,0,0,269,"1,5-pentanediol",water,OCCCCCO,O
+354,"1,2-propanediol__water",22,0,0,8,36,85,114,265,"1,2-propanediol",water,CC(O)CO,O
+26,"1,6-hexanediol__water",255,0,0,0,0,0,0,255,"1,6-hexanediol",water,OCCCCCCO,O
+75,"1-heptanol__1,4-dioxane",126,0,126,0,0,0,0,252,1-heptanol,"1,4-dioxane",CCCCCCCO,C1COCCO1
+333,"1,2-ethanediol__water",26,0,0,10,0,79,135,250,"1,2-ethanediol",water,OCCO,O
+184,ethanol__methanol,63,0,0,105,76,0,0,244,ethanol,methanol,CCO,CO
+28,"1,4-dimethylbenzene__octane",242,0,0,0,0,0,0,242,"1,4-dimethylbenzene",octane,Cc1ccc(C)cc1,CCCCCCCC
+31,tetrahydrofuran__water,220,0,20,0,0,0,0,240,tetrahydrofuran,water,C1CCOC1,O
+29,cycloheptanol__water,222,0,0,0,0,0,0,222,cycloheptanol,water,OC1CCCCCC1,O
+35,1-propanol__dibutyl ether,200,0,0,0,21,0,0,221,1-propanol,dibutyl ether,CCCO,CCCCOCCCC
+30,"1,8-octanediol__water",220,0,0,0,0,0,0,220,"1,8-octanediol",water,OCCCCCCCCO,O
+108,1-butanol__toluene,88,0,88,0,38,0,0,214,1-butanol,toluene,CCCCO,Cc1ccccc1
+32,neopentyl alcohol__water,213,0,0,0,0,0,0,213,neopentyl alcohol,water,CC(C)(C)CO,O
+46,"1,4-dimethylbenzene__decane",180,0,33,0,0,0,0,213,"1,4-dimethylbenzene",decane,Cc1ccc(C)cc1,CCCCCCCCCC
+96,"1-butanol__2,2,4-trimethylpentane",93,0,80,0,38,0,0,211,1-butanol,"2,2,4-trimethylpentane",CCCCO,CC(C)CC(C)(C)C
+34,"2-methyl-1,3-propanediol__water",209,0,0,0,0,0,0,209,"2-methyl-1,3-propanediol",water,CC(CO)CO,O
+44,2-butoxyethanol__water,191,0,18,0,0,0,0,209,2-butoxyethanol,water,CCCCOCCO,O
+95,"1,2-hexanediol__water",96,0,0,0,0,53,60,209,"1,2-hexanediol",water,CCCCC(O)CO,O
+45,decane__methyl tert-butyl ether,181,0,0,0,20,0,0,201,decane,methyl tert-butyl ether,CCCCCCCCCC,COC(C)(C)C
+36,2-propanol__dibutyl ether,200,0,0,0,0,0,0,200,2-propanol,dibutyl ether,CC(C)O,CCCCOCCCC
+51,1-propanol__water,172,0,27,0,0,0,0,199,1-propanol,water,CCCO,O
+37,"3,6-dioxaoctane__water",196,0,0,0,0,0,0,196,"3,6-dioxaoctane",water,CCOCCOCC,O
+74,2-phenylethanol__2-propanol,129,0,66,0,0,0,0,195,2-phenylethanol,2-propanol,OCCc1ccccc1,CC(C)O
+205,1-butanol__dibutyl ether,55,0,55,0,84,0,0,194,1-butanol,dibutyl ether,CCCCO,CCCCOCCCC
+49,nonane__methyl tert-butyl ether,173,0,0,0,20,0,0,193,nonane,methyl tert-butyl ether,CCCCCCCCC,COC(C)(C)C
+70,1-butanol__benzene,138,0,0,0,51,0,0,189,1-butanol,benzene,CCCCO,c1ccccc1
+47,cyclohexylmethanol__water,176,0,0,0,0,0,0,176,cyclohexylmethanol,water,OCC1CCCCC1,O
+48,2-cyclohexylethanol__water,175,0,0,0,0,0,0,175,2-cyclohexylethanol,water,OCCC1CCCCC1,O
+186,1-butanol__hexane,60,0,60,0,23,0,31,174,1-butanol,hexane,CCCCO,CCCCCC
+50,diethoxymethane__water,173,0,0,0,0,0,0,173,diethoxymethane,water,CCOCOCC,O
+57,"2,5,8-trioxanonane__water",154,0,18,0,0,0,0,172,"2,5,8-trioxanonane",water,COCCOCCOC,O
+52,n-octane__nonane,171,0,0,0,0,0,0,171,n-octane,nonane,CCCCCCCC,CCCCCCCCC
+59,"ethanol__2,2,4-trimethylpentane",150,0,0,0,19,0,0,169,ethanol,"2,2,4-trimethylpentane",CCO,CC(C)CC(C)(C)C
+53,pentaerythritol__water,165,0,0,0,0,0,0,165,pentaerythritol,water,OCC(CO)(CO)CO,O
+127,2-propanol__cyclohexane,78,0,78,0,9,0,0,165,2-propanol,cyclohexane,CC(C)O,C1CCCCC1
+123,1-octanol__1-butoxy-2-propanol,80,0,80,0,0,0,0,160,1-octanol,1-butoxy-2-propanol,CCCCCCCCO,CCCCOCC(C)O
+124,1-hexanol__1-butoxy-2-propanol,80,0,80,0,0,0,0,160,1-hexanol,1-butoxy-2-propanol,CCCCCCO,CCCCOCC(C)O
+54,propane__butane,157,0,0,0,0,0,0,157,propane,butane,CCC,CCCC
+55,cyclooctanol__water,156,0,0,0,0,0,0,156,cyclooctanol,water,OC1CCCCCCC1,O
+56,"2,2-dimethyl-1,3-propanediol__water",156,0,0,0,0,0,0,156,"2,2-dimethyl-1,3-propanediol",water,CC(C)(CO)CO,O
+137,"toluene__2,2,4-trimethylpentane",77,0,77,0,0,0,0,154,toluene,"2,2,4-trimethylpentane",Cc1ccccc1,CC(C)CC(C)(C)C
+58,methanol__methyl tert-butyl ether,151,0,0,0,0,0,0,151,methanol,methyl tert-butyl ether,CO,COC(C)(C)C
+80,ethanol__cyclohexane,111,0,39,0,0,0,0,150,ethanol,cyclohexane,CCO,C1CCCCC1
+60,hexane__heptane,149,0,0,0,0,0,0,149,hexane,heptane,CCCCCC,CCCCCCC
+141,"dibutyl ether__ethanol, 2-propoxy-",73,0,73,0,0,0,0,146,dibutyl ether,"ethanol, 2-propoxy-",CCCCOCCCC,CCCOCCO
+61,2-propanol__methyl tert-butyl ether,144,0,0,0,0,0,0,144,2-propanol,methyl tert-butyl ether,CC(C)O,COC(C)(C)C
+62,butan-1-ol__methyl tert-butyl ether,144,0,0,0,0,0,0,144,butan-1-ol,methyl tert-butyl ether,CCCCO,COC(C)(C)C
+143,ethanol__isooctane,72,0,72,0,0,0,0,144,ethanol,isooctane,CCO,CCCCCC(C)C
+214,"butan-1-ol__butane, 1,4-dihydroxy-",50,0,54,0,0,0,40,144,butan-1-ol,"butane, 1,4-dihydroxy-",CCCCO,OCCCCO
+64,propan-1-ol__methyl tert-butyl ether,140,0,0,0,0,0,0,140,propan-1-ol,methyl tert-butyl ether,CCCO,COC(C)(C)C
+65,ethanol__methyl tert-butyl ether,140,0,0,0,0,0,0,140,ethanol,methyl tert-butyl ether,CCO,COC(C)(C)C
+66,pentan-1-ol__methyl tert-butyl ether,140,0,0,0,0,0,0,140,pentan-1-ol,methyl tert-butyl ether,CCCCCO,COC(C)(C)C
+67,pentylcarbinol__methyl tert-butyl ether,140,0,0,0,0,0,0,140,pentylcarbinol,methyl tert-butyl ether,CCCCCCO,COC(C)(C)C
+145,2-butoxyethanol__1-octanol,70,0,70,0,0,0,0,140,2-butoxyethanol,1-octanol,CCCCOCCO,CCCCCCCCO
+146,1-propanol__2-butoxyethanol,70,0,70,0,0,0,0,140,1-propanol,2-butoxyethanol,CCCO,CCCCOCCO
+147,2-butanol__2-butoxyethanol,70,0,70,0,0,0,0,140,2-butanol,2-butoxyethanol,CCC(C)O,CCCCOCCO
+148,2-propanol__2-butoxyethanol,70,0,70,0,0,0,0,140,2-propanol,2-butoxyethanol,CC(C)O,CCCCOCCO
+149,1-hexanol__2-butoxyethanol,70,0,70,0,0,0,0,140,1-hexanol,2-butoxyethanol,CCCCCCO,CCCCOCCO
+150,1-butanol__2-butoxyethanol,70,0,70,0,0,0,0,140,1-butanol,2-butoxyethanol,CCCCO,CCCCOCCO
+68,ribitol__water,139,0,0,0,0,0,0,139,ribitol,water,OC[C@@H](O)[C@@H](O)[C@@H](O)CO,O
+69,"3-methylpentane-1,5-diol__water",138,0,0,0,0,0,0,138,"3-methylpentane-1,5-diol",water,CC(CCO)CCO,O
+72,pentane__nonane,138,0,0,0,0,0,0,138,pentane,nonane,CCCCC,CCCCCCCCC
+111,methylcyclohexane__toluene,85,0,50,0,0,0,0,135,methylcyclohexane,toluene,CC1CCCCC1,Cc1ccccc1
+113,benzene__methylcyclohexane,85,0,50,0,0,0,0,135,benzene,methylcyclohexane,c1ccccc1,CC1CCCCC1
+152,"nonane__2,5,8-trioxanonane",69,0,0,66,0,0,0,135,nonane,"2,5,8-trioxanonane",CCCCCCCCC,COCCOCCOC
+77,ethanol__2-methyl-1-butanol,116,0,18,0,0,0,0,134,ethanol,2-methyl-1-butanol,CCO,CCC(C)CO
+197,1-octanol__dibutyl ether,56,0,56,0,22,0,0,134,1-octanol,dibutyl ether,CCCCCCCCO,CCCCOCCCC
+153,1-butanol__methyl tert-butyl ether,67,0,66,0,0,0,0,133,1-butanol,methyl tert-butyl ether,CCCCO,COC(C)(C)C
+97,toluene__cyclohexane,93,0,39,0,0,0,0,132,toluene,cyclohexane,Cc1ccccc1,C1CCCCC1
+154,"benzenemethanol__1,2-butanediol",66,0,66,0,0,0,0,132,benzenemethanol,"1,2-butanediol",OCc1ccccc1,CCC(O)CO
+156,2-phenylethanol__1-propanol,66,0,66,0,0,0,0,132,2-phenylethanol,1-propanol,OCCc1ccccc1,CCCO
+157,1-propanol__tert-butanol,66,0,66,0,0,0,0,132,1-propanol,tert-butanol,CCCO,CC(C)(C)O
+159,"2-phenylethanol__1,2-butanediol",66,0,66,0,0,0,0,132,2-phenylethanol,"1,2-butanediol",OCCc1ccccc1,CCC(O)CO
+160,2-propanol__tert-butanol,66,0,66,0,0,0,0,132,2-propanol,tert-butanol,CC(C)O,CC(C)(C)O
+161,"(RS)-2-butanol__1,2-butanediol",66,0,66,0,0,0,0,132,(RS)-2-butanol,"1,2-butanediol",CCC(C)O,CCC(O)CO
+163,"1,2-dimethoxyethane__nonane",66,0,0,66,0,0,0,132,"1,2-dimethoxyethane",nonane,COCCOC,CCCCCCCCC
+165,"2-propanol__1,3-propanediol",66,0,66,0,0,0,0,132,2-propanol,"1,3-propanediol",CC(C)O,OCCCO
+171,"1,3-butanediol__1,2-butanediol",66,0,66,0,0,0,0,132,"1,3-butanediol","1,2-butanediol",CC(O)CCO,CCC(O)CO
+172,"1-propanol__1,3-propanediol",66,0,66,0,0,0,0,132,1-propanol,"1,3-propanediol",CCCO,OCCCO
+73,1-propanol__benzene,131,0,0,0,0,0,0,131,1-propanol,benzene,CCCO,c1ccccc1
+195,1-pentanol__dibutyl ether,56,0,56,0,19,0,0,131,1-pentanol,dibutyl ether,CCCCCO,CCCCOCCCC
+697,"1-butanol__1,4-butanediol",0,0,0,0,0,130,0,130,1-butanol,"1,4-butanediol",CCCCO,OCCCCO
+176,octane__methyl tert-butyl ether,64,0,65,0,0,0,0,129,octane,methyl tert-butyl ether,CCCCCCCC,COC(C)(C)C
+179,1-butanol__2-(2-methoxyethoxy)ethanol,63,0,63,0,0,0,0,126,1-butanol,2-(2-methoxyethoxy)ethanol,CCCCO,COCCOCCO
+185,2-methoxyethanol__2-(2-methoxyethoxy)ethanol,61,0,61,0,0,0,0,122,2-methoxyethanol,2-(2-methoxyethoxy)ethanol,COCCO,COCCOCCO
+76,methanol__benzene,121,0,0,0,0,0,0,121,methanol,benzene,CO,c1ccccc1
+189,"1-butanol__3,6-dioxa-1-octanol",60,0,60,0,0,0,0,120,1-butanol,"3,6-dioxa-1-octanol",CCCCO,CCOCCOCCO
+266,ethanol__hexane,39,0,39,0,17,0,23,118,ethanol,hexane,CCO,CCCCCC
+78,"2,5-hexanediol__water",114,0,0,0,0,0,0,114,"2,5-hexanediol",water,CC(O)CCC(C)O,O
+79,pentane__n-octane,114,0,0,0,0,0,0,114,pentane,n-octane,CCCCC,CCCCCCCC
+192,2-methoxyethanol__2-butoxyethanol,57,0,57,0,0,0,0,114,2-methoxyethanol,2-butoxyethanol,COCCO,CCCCOCCO
+281,benzene__tetrahydropyran,36,0,50,0,14,0,14,114,benzene,tetrahydropyran,c1ccccc1,C1CCOCC1
+284,toluene__tetrahydropyran,36,0,50,0,14,0,14,114,toluene,tetrahydropyran,Cc1ccccc1,C1CCOCC1
+228,1-butanol__octane,48,0,48,0,16,0,0,112,1-butanol,octane,CCCCO,CCCCCCCC
+199,"2,2,4-trimethylpentane__methyl tert-butyl ether",55,0,55,0,0,0,0,110,"2,2,4-trimethylpentane",methyl tert-butyl ether,CC(C)CC(C)(C)C,COC(C)(C)C
+200,1-heptanol__dibutyl ether,55,0,55,0,0,0,0,110,1-heptanol,dibutyl ether,CCCCCCCO,CCCCOCCCC
+81,"1-propanol__2,2,4-trimethylpentane",108,0,0,0,0,0,0,108,1-propanol,"2,2,4-trimethylpentane",CCCO,CC(C)CC(C)(C)C
+82,pentane__heptane,107,0,0,0,0,0,0,107,pentane,heptane,CCCCC,CCCCCCC
+83,glycerin__water,107,0,0,0,0,0,0,107,glycerin,water,OCC(O)CO,O
+100,2-(2-methoxyethoxy)ethanol__water,91,0,16,0,0,0,0,107,2-(2-methoxyethoxy)ethanol,water,COCCOCCO,O
+121,"1,4-dimethylbenzene__cyclohexane",81,0,26,0,0,0,0,107,"1,4-dimethylbenzene",cyclohexane,Cc1ccc(C)cc1,C1CCCCC1
+142,"1,3-benzenediol__water",72,0,35,0,0,0,0,107,"1,3-benzenediol",water,Oc1cccc(O)c1,O
+85,propylene glycol__water,106,0,0,0,0,0,0,106,propylene glycol,water,CC(O)CO,O
+118,"2,2-bis(hydroxymethyl)-1,3-propanediol__water",84,0,22,0,0,0,0,106,"2,2-bis(hydroxymethyl)-1,3-propanediol",water,OCC(CO)(CO)CO,O
+86,methanol__ethylbenzene,105,0,0,0,0,0,0,105,methanol,ethylbenzene,CO,CCc1ccccc1
+87,2-methoxyethanol__tert-butyl ethyl ether,105,0,0,0,0,0,0,105,2-methoxyethanol,tert-butyl ethyl ether,COCCO,CCOC(C)(C)C
+88,2-(2-methoxyethoxy)ethanol__tert-butyl ethyl ether,105,0,0,0,0,0,0,105,2-(2-methoxyethoxy)ethanol,tert-butyl ethyl ether,COCCOCCO,CCOC(C)(C)C
+592,methanol__2-propanol,0,0,0,105,0,0,0,105,methanol,2-propanol,CO,CC(C)O
+593,methanol__2-methyl-1-propanol,0,0,0,105,0,0,0,105,methanol,2-methyl-1-propanol,CO,CC(C)CO
+594,methanol__1-butanol,0,0,0,105,0,0,0,105,methanol,1-butanol,CO,CCCCO
+595,methanol__1-propanol,0,0,0,105,0,0,0,105,methanol,1-propanol,CO,CCCO
+193,toluene__methyl tert-butyl ether,57,0,46,0,0,0,0,103,toluene,methyl tert-butyl ether,Cc1ccccc1,COC(C)(C)C
+233,"1,2-ethanediol__1-nonanol",48,0,55,0,0,0,0,103,"1,2-ethanediol",1-nonanol,OCCO,CCCCCCCCCO
+177,1-propanol__cyclopentane,63,0,39,0,0,0,0,102,1-propanol,cyclopentane,CCCO,C1CCCC1
+105,toluene__octane,88,0,13,0,0,0,0,101,toluene,octane,Cc1ccccc1,CCCCCCCC
+90,pentane__hexane,100,0,0,0,0,0,0,100,pentane,hexane,CCCCC,CCCCCC
+91,tetralin__isobutylbenzene,100,0,0,0,0,0,0,100,tetralin,isobutylbenzene,C1CCc2ccccc2C1,CC(C)Cc1ccccc1
+92,heptane__methyl tert-butyl ether,99,0,0,0,0,0,0,99,heptane,methyl tert-butyl ether,CCCCCCC,COC(C)(C)C
+93,ethanol__3-methyl-1-butanol,98,0,0,0,0,0,0,98,ethanol,3-methyl-1-butanol,CCO,CC(C)CCO
+94,ethanol__2-methyl-2-butanol,98,0,0,0,0,0,0,98,ethanol,2-methyl-2-butanol,CCO,CCC(C)(C)O
+190,"1,4-dimethylbenzene__methylcyclohexane",59,0,37,0,0,0,0,96,"1,4-dimethylbenzene",methylcyclohexane,Cc1ccc(C)cc1,CC1CCCCC1
+191,"1,3,5-trimethylbenzene__methylcyclohexane",59,0,37,0,0,0,0,96,"1,3,5-trimethylbenzene",methylcyclohexane,Cc1cc(C)cc(C)c1,CC1CCCCC1
+215,ethylbenzene__1-nonanol,48,0,48,0,0,0,0,96,ethylbenzene,1-nonanol,CCc1ccccc1,CCCCCCCCCO
+216,benzene__2-ethyl-1-hexanol,48,0,48,0,0,0,0,96,benzene,2-ethyl-1-hexanol,c1ccccc1,CCCCC(CC)CO
+217,2-methoxyethanol__1-octanol,48,0,48,0,0,0,0,96,2-methoxyethanol,1-octanol,COCCO,CCCCCCCCO
+218,"1,3-dimethylbenzene__1-nonanol",48,0,48,0,0,0,0,96,"1,3-dimethylbenzene",1-nonanol,Cc1cccc(C)c1,CCCCCCCCCO
+223,2-methoxyethanol__1-hexanol,48,0,48,0,0,0,0,96,2-methoxyethanol,1-hexanol,COCCO,CCCCCCO
+224,"1,4-dimethylbenzene__1-nonanol",48,0,48,0,0,0,0,96,"1,4-dimethylbenzene",1-nonanol,Cc1ccc(C)cc1,CCCCCCCCCO
+225,tetrahydrofuran__n-hexyl alcohol,48,0,48,0,0,0,0,96,tetrahydrofuran,n-hexyl alcohol,C1CCOC1,CCCCCCO
+226,octane__1-octanol,48,0,48,0,0,0,0,96,octane,1-octanol,CCCCCCCC,CCCCCCCCO
+229,1-octanol__decane,48,0,48,0,0,0,0,96,1-octanol,decane,CCCCCCCCO,CCCCCCCCCC
+230,hexane__1-octanol,48,0,48,0,0,0,0,96,hexane,1-octanol,CCCCCC,CCCCCCCCO
+232,1-butanol__decane,48,0,48,0,0,0,0,96,1-butanol,decane,CCCCO,CCCCCCCCCC
+235,"1,2-dimethylbenzene__1-nonanol",48,0,48,0,0,0,0,96,"1,2-dimethylbenzene",1-nonanol,Cc1ccccc1C,CCCCCCCCCO
+236,tetrahydrofuran__octyl alcohol,48,0,48,0,0,0,0,96,tetrahydrofuran,octyl alcohol,C1CCOC1,CCCCCCCCO
+596,methanol__2-methyl-2-propanol,0,0,0,95,0,0,0,95,methanol,2-methyl-2-propanol,CO,CC(C)(C)O
+138,1-butanol__water,75,8,11,0,0,0,0,94,1-butanol,water,CCCCO,O
+320,1-butanol__2-methyltetrahydrofuran,27,0,34,0,33,0,0,94,1-butanol,2-methyltetrahydrofuran,CCCCO,CC1CCCO1
+98,"1,2-dimethoxyethane__water",93,0,0,0,0,0,0,93,"1,2-dimethoxyethane",water,COCCOC,O
+203,1-butanol__heptane,55,0,0,0,38,0,0,93,1-butanol,heptane,CCCCO,CCCCCCC
+99,"benzene__2,2,4-trimethylpentane",92,0,0,0,0,0,0,92,benzene,"2,2,4-trimethylpentane",c1ccccc1,CC(C)CC(C)(C)C
+209,ethylbenzene__methylcyclohexane,52,0,39,0,0,0,0,91,ethylbenzene,methylcyclohexane,CCc1ccccc1,CC1CCCCC1
+101,oxacyclopentane__water,90,0,0,0,0,0,0,90,oxacyclopentane,water,C1CCOC1,O
+241,2-butoxyethan-1-ol__water,45,0,45,0,0,0,0,90,2-butoxyethan-1-ol,water,CCCCOCCO,O
+245,2-(2-methylpropoxy)ethanol__water,45,0,45,0,0,0,0,90,2-(2-methylpropoxy)ethanol,water,CC(C)COCCO,O
+213,1-propanol__cyclohexane,50,0,39,0,0,0,0,89,1-propanol,cyclohexane,CCCO,C1CCCCC1
+269,1-butanol__cyclopentane,39,0,39,0,11,0,0,89,1-butanol,cyclopentane,CCCCO,C1CCCC1
+102,ethyl alcohol__n-butyl alcohol,88,0,0,0,0,0,0,88,ethyl alcohol,n-butyl alcohol,CCO,CCCCO
+103,"glycerol__1,2-propanediol",88,0,0,0,0,0,0,88,glycerol,"1,2-propanediol",OCC(O)CO,CC(O)CO
+104,"glycerol__1,3-propanediol",88,0,0,0,0,0,0,88,glycerol,"1,3-propanediol",OCC(O)CO,OCCCO
+106,glycerol__2-propanol,88,0,0,0,0,0,0,88,glycerol,2-propanol,OCC(O)CO,CC(C)O
+107,ethyl alcohol__pentan-1-ol,88,0,0,0,0,0,0,88,ethyl alcohol,pentan-1-ol,CCO,CCCCCO
+109,ethyl alcohol__propan-1-ol,88,0,0,0,0,0,0,88,ethyl alcohol,propan-1-ol,CCO,CCCO
+110,glycerol__1-propanol,88,0,0,0,0,0,0,88,glycerol,1-propanol,OCC(O)CO,CCCO
+246,"2-methoxyethanol__ethanol, 2-ethoxy-",44,0,44,0,0,0,0,88,2-methoxyethanol,"ethanol, 2-ethoxy-",COCCO,CCOCCO
+112,"1,2-dihydroxyethane__water",85,0,0,0,0,0,0,85,"1,2-dihydroxyethane",water,OCCO,O
+140,"2-propanol__1,3-dioxolane",74,0,11,0,0,0,0,85,2-propanol,"1,3-dioxolane",CC(C)O,C1COCO1
+114,"2-propanol__pentane, 2,2,4-trimethyl-",84,0,0,0,0,0,0,84,2-propanol,"pentane, 2,2,4-trimethyl-",CC(C)O,CC(C)CC(C)(C)C
+115,"tetrahydropyran__pentane, 2,2,4-trimethyl-",84,0,0,0,0,0,0,84,tetrahydropyran,"pentane, 2,2,4-trimethyl-",C1CCOCC1,CC(C)CC(C)(C)C
+116,"1-hexanol__2,2,4-trimethylpentane",84,0,0,0,0,0,0,84,1-hexanol,"2,2,4-trimethylpentane",CCCCCCO,CC(C)CC(C)(C)C
+117,"1-heptanol__2,2,4-trimethylpentane",84,0,0,0,0,0,0,84,1-heptanol,"2,2,4-trimethylpentane",CCCCCCCO,CC(C)CC(C)(C)C
+119,2-propanol__tetrahydropyran,84,0,0,0,0,0,0,84,2-propanol,tetrahydropyran,CC(C)O,C1CCOCC1
+120,ethanol__benzyl alcohol,84,0,0,0,0,0,0,84,ethanol,benzyl alcohol,CCO,OCc1ccccc1
+252,toluene__2-hexanol,42,0,42,0,0,0,0,84,toluene,2-hexanol,Cc1ccccc1,CCCCC(C)O
+255,toluene__2-heptanol,42,0,42,0,0,0,0,84,toluene,2-heptanol,Cc1ccccc1,CCCCCC(C)O
+257,toluene__2-octanol,42,0,42,0,0,0,0,84,toluene,2-octanol,Cc1ccccc1,CCCCCCC(C)O
+305,1-butanol__methylcyclohexane,33,0,11,0,38,0,0,82,1-butanol,methylcyclohexane,CCCCO,CC1CCCCC1
+122,1-butanol__2-methyl-1-propanol,81,0,0,0,0,0,0,81,1-butanol,2-methyl-1-propanol,CCCCO,CC(C)CO
+261,"1,2-benzenediol__water",40,0,40,0,0,0,0,80,"1,2-benzenediol",water,Oc1ccccc1O,O
+125,2-methyl-1-propanol__water,79,0,0,0,0,0,0,79,2-methyl-1-propanol,water,CC(C)CO,O
+126,"1-pentanol__2,2,4-trimethylpentane",79,0,0,0,0,0,0,79,1-pentanol,"2,2,4-trimethylpentane",CCCCCO,CC(C)CC(C)(C)C
+263,2-propanol__cyclopentane,39,0,39,0,0,0,0,78,2-propanol,cyclopentane,CC(C)O,C1CCCC1
+264,ethanol__cyclopentane,39,0,39,0,0,0,0,78,ethanol,cyclopentane,CCO,C1CCCC1
+265,toluene__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,toluene,tert-butyl ethyl ether,Cc1ccccc1,CCOC(C)(C)C
+267,"bis(2-hydroxyethyl) ether__ethanol, 2-propoxy-",39,0,0,39,0,0,0,78,bis(2-hydroxyethyl) ether,"ethanol, 2-propoxy-",OCCOCCO,CCCOCCO
+268,"triethylene glycol__ethanol, 2-propoxy-",39,0,0,39,0,0,0,78,triethylene glycol,"ethanol, 2-propoxy-",OCCOCCOCCO,CCCOCCO
+271,ethylbenzene__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,ethylbenzene,tert-butyl ethyl ether,CCc1ccccc1,CCOC(C)(C)C
+272,benzene__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,benzene,tert-butyl ethyl ether,c1ccccc1,CCOC(C)(C)C
+273,ethylbenzene__cyclohexane,39,0,39,0,0,0,0,78,ethylbenzene,cyclohexane,CCc1ccccc1,C1CCCCC1
+274,2-methyl-2-propanol__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,2-methyl-2-propanol,tert-butyl ethyl ether,CC(C)(C)O,CCOC(C)(C)C
+275,"2,2,4-trimethylpentane__tert-butyl ethyl ether",39,0,39,0,0,0,0,78,"2,2,4-trimethylpentane",tert-butyl ethyl ether,CC(C)CC(C)(C)C,CCOC(C)(C)C
+276,cyclopentane__2-pentanol,39,0,39,0,0,0,0,78,cyclopentane,2-pentanol,C1CCCC1,CCCC(C)O
+277,2-methyl-2-butanol__tetrahydrofuran,39,0,0,0,0,0,39,78,2-methyl-2-butanol,tetrahydrofuran,CCC(C)(C)O,C1CCOC1
+279,ethanol__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,ethanol,tert-butyl ethyl ether,CCO,CCOC(C)(C)C
+128,"1,2-ethanediol__3-methylphenol",77,0,0,0,0,0,0,77,"1,2-ethanediol",3-methylphenol,OCCO,Cc1cccc(O)c1
+129,"n-octane__2,2,4-trimethylpentane",77,0,0,0,0,0,0,77,n-octane,"2,2,4-trimethylpentane",CCCCCCCC,CC(C)CC(C)(C)C
+130,ethanol__n-octane,77,0,0,0,0,0,0,77,ethanol,n-octane,CCO,CCCCCCCC
+131,1-butanol__n-octane,77,0,0,0,0,0,0,77,1-butanol,n-octane,CCCCO,CCCCCCCC
+132,1-pentanol__n-octane,77,0,0,0,0,0,0,77,1-pentanol,n-octane,CCCCCO,CCCCCCCC
+133,1-octanol__1-nonanol,77,0,0,0,0,0,0,77,1-octanol,1-nonanol,CCCCCCCCO,CCCCCCCCCO
+134,"n-heptane__2,2,4-trimethylpentane",77,0,0,0,0,0,0,77,n-heptane,"2,2,4-trimethylpentane",CCCCCCC,CC(C)CC(C)(C)C
+135,"4-methylphenol__1,2-ethanediol",77,0,0,0,0,0,0,77,4-methylphenol,"1,2-ethanediol",Cc1ccc(O)cc1,OCCO
+136,1-propanol__n-octane,77,0,0,0,0,0,0,77,1-propanol,n-octane,CCCO,CCCCCCCC
+600,ethanol__2-propanol,0,0,0,0,76,0,0,76,ethanol,2-propanol,CCO,CC(C)O
+139,"1,5-hexanediol__water",75,0,0,0,0,0,0,75,"1,5-hexanediol",water,CC(O)CCCCO,O
+601,ethanol__1-propanol,0,0,0,0,74,0,0,74,ethanol,1-propanol,CCO,CCCO
+144,1-butanol__2-methyl-2-propanol,72,0,0,0,0,0,0,72,1-butanol,2-methyl-2-propanol,CCCCO,CC(C)(C)O
+282,o-xylene__tetrahydropyran,36,0,36,0,0,0,0,72,o-xylene,tetrahydropyran,Cc1ccccc1C,C1CCOCC1
+151,tert-butanol__heptane,70,0,0,0,0,0,0,70,tert-butanol,heptane,CC(C)(C)O,CCCCCCC
+566,1-butanol__tetrahydropyran,0,0,35,0,33,0,0,68,1-butanol,tetrahydropyran,CCCCO,C1CCOCC1
+288,"2,5,8-trioxanonane__heptane",34,0,0,33,0,0,0,67,"2,5,8-trioxanonane",heptane,COCCOCCOC,CCCCCCC
+155,"1,2-dihydroxypropane__amylcarbinol",66,0,0,0,0,0,0,66,"1,2-dihydroxypropane",amylcarbinol,CC(O)CO,CCCCCCO
+158,"1,2-dihydroxypropane__methyl alcohol",66,0,0,0,0,0,0,66,"1,2-dihydroxypropane",methyl alcohol,CC(O)CO,CO
+162,"1,4-dimethylbenzene__heptane",66,0,0,0,0,0,0,66,"1,4-dimethylbenzene",heptane,Cc1ccc(C)cc1,CCCCCCC
+164,butylcyclohexane__JP-10,66,0,0,0,0,0,0,66,butylcyclohexane,JP-10,CCCCC1CCCCC1,C1CC2C3CCC(C3)C2C1
+166,"1,2-dihydroxypropane__1-nonanol",66,0,0,0,0,0,0,66,"1,2-dihydroxypropane",1-nonanol,CC(O)CO,CCCCCCCCCO
+167,"1,2,4-trimethylcyclohexane__JP-10",66,0,0,0,0,0,0,66,"1,2,4-trimethylcyclohexane",JP-10,CC1CCC(C)C(C)C1,C1CC2C3CCC(C3)C2C1
+168,methylcyclohexane__JP-10,66,0,0,0,0,0,0,66,methylcyclohexane,JP-10,CC1CCCCC1,C1CC2C3CCC(C3)C2C1
+169,ethylcyclohexane__JP-10,66,0,0,0,0,0,0,66,ethylcyclohexane,JP-10,CCC1CCCCC1,C1CC2C3CCC(C3)C2C1
+170,"1,2-dihydroxypropane__1-octanol",66,0,0,0,0,0,0,66,"1,2-dihydroxypropane",1-octanol,CC(O)CO,CCCCCCCCO
+262,toluene__hexane,39,0,11,0,16,0,0,66,toluene,hexane,Cc1ccccc1,CCCCCC
+173,"1,3,5-trimethylbenzene__octane",64,0,0,0,0,0,0,64,"1,3,5-trimethylbenzene",octane,Cc1cc(C)cc(C)c1,CCCCCCCC
+174,methanol__cyclohexane,64,0,0,0,0,0,0,64,methanol,cyclohexane,CO,C1CCCCC1
+175,"1,3-dimethylbenzene__octane",64,0,0,0,0,0,0,64,"1,3-dimethylbenzene",octane,Cc1cccc(C)c1,CCCCCCCC
+307,dimethylglycol__heptane,33,0,0,31,0,0,0,64,dimethylglycol,heptane,COCCOC,CCCCCCC
+311,3-methylphenol__1-nonanol,32,0,32,0,0,0,0,64,3-methylphenol,1-nonanol,Cc1cccc(O)c1,CCCCCCCCCO
+312,2-methylphenol__1-nonanol,32,0,32,0,0,0,0,64,2-methylphenol,1-nonanol,Cc1ccccc1O,CCCCCCCCCO
+313,methyl phenyl ether__1-nonanol,32,0,32,0,0,0,0,64,methyl phenyl ether,1-nonanol,COc1ccccc1,CCCCCCCCCO
+314,4-methylphenol__1-nonanol,32,0,32,0,0,0,0,64,4-methylphenol,1-nonanol,Cc1ccc(O)cc1,CCCCCCCCCO
+178,ethanol__2-methyl-2-propanol,63,0,0,0,0,0,0,63,ethanol,2-methyl-2-propanol,CCO,CC(C)(C)O
+180,2-phenylethanol__benzyl alcohol,63,0,0,0,0,0,0,63,2-phenylethanol,benzyl alcohol,OCCc1ccccc1,OCc1ccccc1
+181,"2,2,4-trimethylpentane__1,3-dioxolane",63,0,0,0,0,0,0,63,"2,2,4-trimethylpentane","1,3-dioxolane",CC(C)CC(C)(C)C,C1COCO1
+182,2-propanol__benzyl alcohol,63,0,0,0,0,0,0,63,2-propanol,benzyl alcohol,CC(C)O,OCc1ccccc1
+183,"2-methyl-2-propanol__2,2,4-trimethylpentane",63,0,0,0,0,0,0,63,2-methyl-2-propanol,"2,2,4-trimethylpentane",CC(C)(C)O,CC(C)CC(C)(C)C
+221,ethylbenzene__cyclooctane,48,0,13,0,0,0,0,61,ethylbenzene,cyclooctane,CCc1ccccc1,C1CCCCCCC1
+234,toluene__cyclooctane,48,0,13,0,0,0,0,61,toluene,cyclooctane,Cc1ccccc1,C1CCCCCCC1
+239,benzene__cyclooctane,48,0,13,0,0,0,0,61,benzene,cyclooctane,c1ccccc1,C1CCCCCCC1
+602,"(RS)-2-butanol__1,1-dimethylethyl methyl ether",0,0,0,0,61,0,0,61,(RS)-2-butanol,"1,1-dimethylethyl methyl ether",CCC(C)O,COC(C)(C)C
+187,"1,2-dihydroxypropane__n-propyl alcohol",60,0,0,0,0,0,0,60,"1,2-dihydroxypropane",n-propyl alcohol,CC(O)CO,CCCO
+188,ethanol__n-decane,60,0,0,0,0,0,0,60,ethanol,n-decane,CCO,CCCCCCCCCC
+319,"furfuryl alcohol, tetrahydro-__water",30,0,30,0,0,0,0,60,"furfuryl alcohol, tetrahydro-",water,OCC1CCCO1,O
+583,cyclohexane__tetrahydropyran,0,0,13,0,32,0,14,59,cyclohexane,tetrahydropyran,C1CCCCC1,C1CCOCC1
+603,"ethanol, 2-ethoxy-__octane",0,0,0,0,59,0,0,59,"ethanol, 2-ethoxy-",octane,CCOCCO,CCCCCCCC
+260,benzene__heptane,40,0,18,0,0,0,0,58,benzene,heptane,c1ccccc1,CCCCCCC
+604,"ethanol, 2-ethoxy-__cyclohexane",0,0,0,0,58,0,0,58,"ethanol, 2-ethoxy-",cyclohexane,CCOCCO,C1CCCCC1
+243,toluene__heptane,45,0,12,0,0,0,0,57,toluene,heptane,Cc1ccccc1,CCCCCCC
+605,1-butanol__5-oxanonane,0,0,0,0,57,0,0,57,1-butanol,5-oxanonane,CCCCO,CCCCOCCCC
+194,n-propanol__water,56,0,0,0,0,0,0,56,n-propanol,water,CCCO,O
+196,"1-hexanol__1,4-dioxane",56,0,0,0,0,0,0,56,1-hexanol,"1,4-dioxane",CCCCCCO,C1COCCO1
+198,"1,4-dimethylbenzene__pentylcarbinol",55,0,0,0,0,0,0,55,"1,4-dimethylbenzene",pentylcarbinol,Cc1ccc(C)cc1,CCCCCCO
+201,methanol__3-methylphenol,55,0,0,0,0,0,0,55,methanol,3-methylphenol,CO,Cc1cccc(O)c1
+202,2-propanol__1-propanol,55,0,0,0,0,0,0,55,2-propanol,1-propanol,CC(C)O,CCCO
+204,1-octanol__heptane,55,0,0,0,0,0,0,55,1-octanol,heptane,CCCCCCCCO,CCCCCCC
+206,cyclohexane__JP-10,55,0,0,0,0,0,0,55,cyclohexane,JP-10,C1CCCCC1,C1CC2C3CCC(C3)C2C1
+207,methanol__4-methylphenol,55,0,0,0,0,0,0,55,methanol,4-methylphenol,CO,Cc1ccc(O)cc1
+208,"pentyl alcohol__1,2-dimethoxyethane",54,0,0,0,0,0,0,54,pentyl alcohol,"1,2-dimethoxyethane",CCCCCO,COCCOC
+324,"1,3-dimethylbenzene__cyclooctane",27,0,27,0,0,0,0,54,"1,3-dimethylbenzene",cyclooctane,Cc1cccc(C)c1,C1CCCCCCC1
+310,1-propanol__isopropyl ether,32,0,21,0,0,0,0,53,1-propanol,isopropyl ether,CCCO,CC(C)OC(C)C
+325,"1,2-dimethylbenzene__methylcyclohexane",26,0,26,0,0,0,0,52,"1,2-dimethylbenzene",methylcyclohexane,Cc1ccccc1C,CC1CCCCC1
+326,"1,3-dimethylbenzene__methylcyclohexane",26,0,26,0,0,0,0,52,"1,3-dimethylbenzene",methylcyclohexane,Cc1cccc(C)c1,CC1CCCCC1
+327,"1,4-dimethylbenzene__cyclopentane",26,0,26,0,0,0,0,52,"1,4-dimethylbenzene",cyclopentane,Cc1ccc(C)cc1,C1CCCC1
+328,"1,2-dimethylbenzene__cyclohexane",26,0,26,0,0,0,0,52,"1,2-dimethylbenzene",cyclohexane,Cc1ccccc1C,C1CCCCC1
+329,"1,3-dimethylbenzene__cyclopentane",26,0,26,0,0,0,0,52,"1,3-dimethylbenzene",cyclopentane,Cc1cccc(C)c1,C1CCCC1
+330,"1,2-dimethylbenzene__cyclooctane",26,0,26,0,0,0,0,52,"1,2-dimethylbenzene",cyclooctane,Cc1ccccc1C,C1CCCCCCC1
+331,"1,3,5-trimethylbenzene__cyclopentane",26,0,26,0,0,0,0,52,"1,3,5-trimethylbenzene",cyclopentane,Cc1cc(C)cc(C)c1,C1CCCC1
+332,"1,3,5-trimethylbenzene__cyclohexane",26,0,26,0,0,0,0,52,"1,3,5-trimethylbenzene",cyclohexane,Cc1cc(C)cc(C)c1,C1CCCCC1
+334,"1,3,5-trimethylbenzene__cyclooctane",26,0,26,0,0,0,0,52,"1,3,5-trimethylbenzene",cyclooctane,Cc1cc(C)cc(C)c1,C1CCCCCCC1
+336,"1,3-dimethylbenzene__cyclohexane",26,0,26,0,0,0,0,52,"1,3-dimethylbenzene",cyclohexane,Cc1cccc(C)c1,C1CCCCC1
+337,"1,4-dimethylbenzene__cyclooctane",26,0,26,0,0,0,0,52,"1,4-dimethylbenzene",cyclooctane,Cc1ccc(C)cc1,C1CCCCCCC1
+338,"1,2-dimethylbenzene__cyclopentane",26,0,26,0,0,0,0,52,"1,2-dimethylbenzene",cyclopentane,Cc1ccccc1C,C1CCCC1
+568,"cyclohexane__1,4-dioxane",0,0,33,0,19,0,0,52,cyclohexane,"1,4-dioxane",C1CCCCC1,C1COCCO1
+606,"hexane__ethanol, 2-ethoxy-",0,0,0,0,51,0,0,51,hexane,"ethanol, 2-ethoxy-",CCCCCC,CCOCCO
+607,1-pentanol__cyclohexane,0,0,0,0,51,0,0,51,1-pentanol,cyclohexane,CCCCCO,C1CCCCC1
+210,"1,2-ethanediol__1-hexanol",50,0,0,0,0,0,0,50,"1,2-ethanediol",1-hexanol,OCCO,CCCCCCO
+211,"1-butanol__1,2-ethanediol",50,0,0,0,0,0,0,50,1-butanol,"1,2-ethanediol",CCCCO,OCCO
+212,"1,2-ethanediol__1-octanol",50,0,0,0,0,0,0,50,"1,2-ethanediol",1-octanol,OCCO,CCCCCCCCO
+219,bis(2-hydroxyethyl) ether__butylmethylcarbinol,48,0,0,0,0,0,0,48,bis(2-hydroxyethyl) ether,butylmethylcarbinol,OCCOCCO,CCCCC(C)O
+220,"benzene__butane, 2-methoxy-2-methyl-",48,0,0,0,0,0,0,48,benzene,"butane, 2-methoxy-2-methyl-",c1ccccc1,CCC(C)(C)OC
+222,sec-propyl alcohol__bis(2-hydroxyethyl) ether,48,0,0,0,0,0,0,48,sec-propyl alcohol,bis(2-hydroxyethyl) ether,CC(C)O,OCCOCCO
+227,"2,2,4-trimethylpentane__butane, 2-methoxy-2-methyl-",48,0,0,0,0,0,0,48,"2,2,4-trimethylpentane","butane, 2-methoxy-2-methyl-",CC(C)CC(C)(C)C,CCC(C)(C)OC
+231,butan-2-ol__bis(2-hydroxyethyl) ether,48,0,0,0,0,0,0,48,butan-2-ol,bis(2-hydroxyethyl) ether,CCC(C)O,OCCOCCO
+237,bis(2-hydroxyethyl) ether__amylmethylcarbinol,48,0,0,0,0,0,0,48,bis(2-hydroxyethyl) ether,amylmethylcarbinol,OCCOCCO,CCCCCCCO
+238,bis(2-hydroxyethyl) ether__pentan-2-ol,48,0,0,0,0,0,0,48,bis(2-hydroxyethyl) ether,pentan-2-ol,OCCOCCO,CCCC(C)O
+283,methylcyclohexane__1-heptanol,36,0,12,0,0,0,0,48,methylcyclohexane,1-heptanol,CC1CCCCC1,CCCCCCCO
+286,benzene__nonane,35,0,13,0,0,0,0,48,benzene,nonane,c1ccccc1,CCCCCCCCC
+344,2-hydroxymethylfuran__water,24,0,24,0,0,0,0,48,2-hydroxymethylfuran,water,OCc1occc1,O
+287,ethylbenzene__heptane,34,0,12,0,0,0,0,46,ethylbenzene,heptane,CCc1ccccc1,CCCCCCC
+240,1-hexanol__heptane,45,0,0,0,0,0,0,45,1-hexanol,heptane,CCCCCCO,CCCCCCC
+242,isopropanol__isobutyl alcohol,45,0,0,0,0,0,0,45,isopropanol,isobutyl alcohol,CC(C)O,CC(C)CO
+244,"ethanol__1,2-dimethoxyethane",45,0,0,0,0,0,0,45,ethanol,"1,2-dimethoxyethane",CCO,COCCOC
+597,pentan-1-ol__n-octane,0,0,0,45,0,0,0,45,pentan-1-ol,n-octane,CCCCCO,CCCCCCCC
+598,n-octane__butyl oxide,0,0,0,45,0,0,0,45,n-octane,butyl oxide,CCCCCCCC,CCCCOCCCC
+599,pentan-1-ol__butyl oxide,0,0,0,45,0,0,0,45,pentan-1-ol,butyl oxide,CCCCCO,CCCCOCCCC
+247,"1,2-dimethoxyethane__1-octanol",44,0,0,0,0,0,0,44,"1,2-dimethoxyethane",1-octanol,COCCOC,CCCCCCCCO
+248,n-propyl alcohol__isobutyl alcohol,44,0,0,0,0,0,0,44,n-propyl alcohol,isobutyl alcohol,CCCO,CC(C)CO
+290,"2-butoxyethanol__1-butanol, 3-methyl-",33,0,11,0,0,0,0,44,2-butoxyethanol,"1-butanol, 3-methyl-",CCCCOCCO,CC(C)CCO
+291,1-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,1-propanol,methylcyclohexane,CCCO,CC1CCCCC1
+292,1-butanol__methoxybenzene,33,0,11,0,0,0,0,44,1-butanol,methoxybenzene,CCCCO,COc1ccccc1
+294,methoxybenzene__methylcyclohexane,33,0,11,0,0,0,0,44,methoxybenzene,methylcyclohexane,COc1ccccc1,CC1CCCCC1
+295,1-pentanol__methoxybenzene,33,0,11,0,0,0,0,44,1-pentanol,methoxybenzene,CCCCCO,COc1ccccc1
+296,2-methyl-1-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,2-methyl-1-propanol,methylcyclohexane,CC(C)CO,CC1CCCCC1
+297,methylcyclohexane__3-methyl-1-butanol,33,0,11,0,0,0,0,44,methylcyclohexane,3-methyl-1-butanol,CC1CCCCC1,CC(C)CCO
+298,2-propanol__methoxybenzene,33,0,11,0,0,0,0,44,2-propanol,methoxybenzene,CC(C)O,COc1ccccc1
+299,2-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,2-propanol,methylcyclohexane,CC(C)O,CC1CCCCC1
+300,1-propanol__methoxybenzene,33,0,11,0,0,0,0,44,1-propanol,methoxybenzene,CCCO,COc1ccccc1
+301,ethanol__methoxybenzene,33,0,11,0,0,0,0,44,ethanol,methoxybenzene,CCO,COc1ccccc1
+306,methoxybenzene__3-methyl-1-butanol,33,0,11,0,0,0,0,44,methoxybenzene,3-methyl-1-butanol,COc1ccccc1,CC(C)CCO
+346,ethanol__isopropyl ether,24,0,0,0,19,0,0,43,ethanol,isopropyl ether,CCO,CC(C)OC(C)C
+249,"1,3,5-trimethylbenzene__2-methoxyethanol",42,0,0,0,0,0,0,42,"1,3,5-trimethylbenzene",2-methoxyethanol,Cc1cc(C)cc(C)c1,COCCO
+250,"1,4-dimethylbenzene__hexane",42,0,0,0,0,0,0,42,"1,4-dimethylbenzene",hexane,Cc1ccc(C)cc1,CCCCCC
+251,"1,3,5-trimethylbenzene__1,2-dimethoxyethane",42,0,0,0,0,0,0,42,"1,3,5-trimethylbenzene","1,2-dimethoxyethane",Cc1cc(C)cc(C)c1,COCCOC
+253,"1,2,4-trimethylbenzene__1,2-dimethoxyethane",42,0,0,0,0,0,0,42,"1,2,4-trimethylbenzene","1,2-dimethoxyethane",CC1=CC(=C(C)C=C1)C,COCCOC
+254,"1,2,4-trimethylbenzene__2-methoxyethanol",42,0,0,0,0,0,0,42,"1,2,4-trimethylbenzene",2-methoxyethanol,CC1=CC(=C(C)C=C1)C,COCCO
+256,toluene__1-octanol,42,0,0,0,0,0,0,42,toluene,1-octanol,Cc1ccccc1,CCCCCCCCO
+258,toluene__1-heptanol,42,0,0,0,0,0,0,42,toluene,1-heptanol,Cc1ccccc1,CCCCCCCO
+371,ethylene glycol methyl ether__water,21,0,21,0,0,0,0,42,ethylene glycol methyl ether,water,COCCO,O
+372,1-propanol__tert-amyl methyl ether,21,0,21,0,0,0,0,42,1-propanol,tert-amyl methyl ether,CCCO,CCC(C)(C)OC
+373,1-propanol__methyl tert-butyl ether,21,0,21,0,0,0,0,42,1-propanol,methyl tert-butyl ether,CCCO,COC(C)(C)C
+408,"isopropyl ether__2,2,4-trimethylpentane",13,0,10,0,19,0,0,42,isopropyl ether,"2,2,4-trimethylpentane",CC(C)OC(C)C,CC(C)CC(C)(C)C
+577,"1,2-dimethylbenzene__tetrahydropyran",0,0,14,0,14,0,14,42,"1,2-dimethylbenzene",tetrahydropyran,Cc1ccccc1C,C1CCOCC1
+578,n-hexane__tetrahydropyran,0,0,14,0,14,0,14,42,n-hexane,tetrahydropyran,CCCCCC,C1CCOCC1
+579,"1,3-dimethylbenzene__tetrahydropyran",0,0,14,0,14,0,14,42,"1,3-dimethylbenzene",tetrahydropyran,Cc1cccc(C)c1,C1CCOCC1
+580,tetrahydropyran__heptane,0,0,14,0,14,0,14,42,tetrahydropyran,heptane,C1CCOCC1,CCCCCCC
+581,"1,4-dimethylbenzene__tetrahydropyran",0,0,14,0,14,0,14,42,"1,4-dimethylbenzene",tetrahydropyran,Cc1ccc(C)cc1,C1CCOCC1
+608,n-heptane__2-pentanol,0,0,0,0,42,0,0,42,n-heptane,2-pentanol,CCCCCCC,CCCC(C)O
+609,pentan-1-ol__isooctane,0,0,0,0,42,0,0,42,pentan-1-ol,isooctane,CCCCCO,CCCCCC(C)C
+610,1-pentanol__toluene,0,0,0,0,42,0,0,42,1-pentanol,toluene,CCCCCO,Cc1ccccc1
+611,pentan-1-ol__heptane,0,0,0,0,42,0,0,42,pentan-1-ol,heptane,CCCCCO,CCCCCCC
+612,"2,2,4-trimethylpentane__2-pentanol",0,0,0,0,42,0,0,42,"2,2,4-trimethylpentane",2-pentanol,CC(C)CC(C)(C)C,CCCC(C)O
+259,xyliton__water,40,0,0,0,0,0,0,40,xyliton,water,OC[C@H](O)C(O)[C@H](O)CO,O
+349,"3,6-dioxa-1-octanol__water",24,0,16,0,0,0,0,40,"3,6-dioxa-1-octanol",water,CCOCCOCCO,O
+270,cyclohexane__2-pentanol,39,0,0,0,0,0,0,39,cyclohexane,2-pentanol,C1CCCCC1,CCCC(C)O
+278,cyclohexane__heptane,39,0,0,0,0,0,0,39,cyclohexane,heptane,C1CCCCC1,CCCCCCC
+613,"2-methyl-2-butanol__1,1-dimethylethyl methyl ether",0,0,0,0,39,0,0,39,2-methyl-2-butanol,"1,1-dimethylethyl methyl ether",CCC(C)(C)O,COC(C)(C)C
+377,1-propanol__2-methyl-1-butanol,19,0,19,0,0,0,0,38,1-propanol,2-methyl-1-butanol,CCCO,CCC(C)CO
+378,1-propanol__3-methyl-1-butanol,19,0,19,0,0,0,0,38,1-propanol,3-methyl-1-butanol,CCCO,CC(C)CCO
+379,methanol__2-methyl-1-butanol,19,0,19,0,0,0,0,38,methanol,2-methyl-1-butanol,CO,CCC(C)CO
+383,"hexane__ether, methyl tert-pentyl",19,0,0,0,0,0,19,38,hexane,"ether, methyl tert-pentyl",CCCCCC,CCC(C)(C)OC
+614,"5-oxanonane__2,2,4-trimethylpentane",0,0,0,0,38,0,0,38,5-oxanonane,"2,2,4-trimethylpentane",CCCCOCCCC,CC(C)CC(C)(C)C
+615,heptane__dibutyl ether,0,0,0,0,38,0,0,38,heptane,dibutyl ether,CCCCCCC,CCCCOCCCC
+616,methylcyclohexane__5-oxanonane,0,0,0,0,38,0,0,38,methylcyclohexane,5-oxanonane,CC1CCCCC1,CCCCOCCCC
+617,toluene__5-oxanonane,0,0,0,0,38,0,0,38,toluene,5-oxanonane,Cc1ccccc1,CCCCOCCCC
+280,octane__heptane,37,0,0,0,0,0,0,37,octane,heptane,CCCCCCCC,CCCCCCC
+350,ethylbenzene__hexane,24,0,13,0,0,0,0,37,ethylbenzene,hexane,CCc1ccccc1,CCCCCC
+285,"1,2-dimethylbenzene__1,2-dimethoxyethane",36,0,0,0,0,0,0,36,"1,2-dimethylbenzene","1,2-dimethoxyethane",Cc1ccccc1C,COCCOC
+335,1-pentanol__cyclopentane,26,0,0,0,10,0,0,36,1-pentanol,cyclopentane,CCCCCO,C1CCCC1
+386,water__dipropylene glycol monomethyl ether,18,0,18,0,0,0,0,36,water,dipropylene glycol monomethyl ether,O,COC(C)COC(C)CO
+387,2-isopropoxyethanol__water,18,0,18,0,0,0,0,36,2-isopropoxyethanol,water,CC(C)OCCO,O
+618,"benzene__ethanol, 2-ethoxy-",0,0,0,0,36,0,0,36,benzene,"ethanol, 2-ethoxy-",c1ccccc1,CCOCCO
+342,1-heptanol__cyclopentane,24,0,0,0,11,0,0,35,1-heptanol,cyclopentane,CCCCCCCO,C1CCCC1
+351,toluene__nonane,23,0,12,0,0,0,0,35,toluene,nonane,Cc1ccccc1,CCCCCCCCC
+619,ethanol__benzene,0,0,0,0,35,0,0,35,ethanol,benzene,CCO,c1ccccc1
+289,"methoxybenzene__1,4-dioxane",33,0,0,0,0,0,0,33,methoxybenzene,"1,4-dioxane",COc1ccccc1,C1COCCO1
+293,"1,2-propanediol__1,2-ethanediol",33,0,0,0,0,0,0,33,"1,2-propanediol","1,2-ethanediol",CC(O)CO,OCCO
+302,"1,2-propanediol__1,3-propanediol",33,0,0,0,0,0,0,33,"1,2-propanediol","1,3-propanediol",CC(O)CO,OCCCO
+303,"1,4-dimethylbenzene__1,2-dimethoxyethane",33,0,0,0,0,0,0,33,"1,4-dimethylbenzene","1,2-dimethoxyethane",Cc1ccc(C)cc1,COCCOC
+304,methylcyclohexane__exo-tetrahydrodicyclopentadiene,33,0,0,0,0,0,0,33,methylcyclohexane,exo-tetrahydrodicyclopentadiene,CC1CCCCC1,C1CC2C3CCC(C3)C2C1
+308,"1,2-propanediol__pentylcarbinol",33,0,0,0,0,0,0,33,"1,2-propanediol",pentylcarbinol,CC(O)CO,CCCCCCO
+309,"1,2-ethanediol__1,3-propanediol",33,0,0,0,0,0,0,33,"1,2-ethanediol","1,3-propanediol",OCCO,OCCCO
+567,"1,4-dioxane__cyclopentane",0,0,33,0,0,0,0,33,"1,4-dioxane",cyclopentane,C1COCCO1,C1CCCC1
+569,"benzene__1,4-dioxane",0,0,33,0,0,0,0,33,benzene,"1,4-dioxane",c1ccccc1,C1COCCO1
+389,2-methyl-1-propanol__hexane,16,0,16,0,0,0,0,32,2-methyl-1-propanol,hexane,CC(C)CO,CCCCCC
+390,2-methyl-1-propanol__decane,16,0,16,0,0,0,0,32,2-methyl-1-propanol,decane,CC(C)CO,CCCCCCCCCC
+391,2-methyl-1-propanol__octane,16,0,16,0,0,0,0,32,2-methyl-1-propanol,octane,CC(C)CO,CCCCCCCC
+315,"1,3-dimethylbenzene__hexane",31,0,0,0,0,0,0,31,"1,3-dimethylbenzene",hexane,Cc1cccc(C)c1,CCCCCC
+316,xylitol__water,30,0,0,0,0,0,0,30,xylitol,water,OC[C@@H](O)[C@H](O)[C@@H](O)CO,O
+317,propan-1-ol__water,30,0,0,0,0,0,0,30,propan-1-ol,water,CCCO,O
+318,"1,2-propanediol__1-heptanol",30,0,0,0,0,0,0,30,"1,2-propanediol",1-heptanol,CC(O)CO,CCCCCCCO
+399,2-phenylethanol__ethoxybenzene,13,0,0,0,17,0,0,30,2-phenylethanol,ethoxybenzene,OCCc1ccccc1,CCOc1ccccc1
+570,benzyl alcohol__1-octanol,0,0,30,0,0,0,0,30,benzyl alcohol,1-octanol,OCc1ccccc1,CCCCCCCCO
+571,benzyl alcohol__1-heptanol,0,0,30,0,0,0,0,30,benzyl alcohol,1-heptanol,OCc1ccccc1,CCCCCCCO
+572,benzyl alcohol__1-nonanol,0,0,30,0,0,0,0,30,benzyl alcohol,1-nonanol,OCc1ccccc1,CCCCCCCCCO
+620,benzene__5-oxanonane,0,0,0,0,30,0,0,30,benzene,5-oxanonane,c1ccccc1,CCCCOCCCC
+402,cyclohexane__octane,13,0,0,0,16,0,0,29,cyclohexane,octane,C1CCCCC1,CCCCCCCC
+412,benzyl alcohol__ethoxybenzene,12,0,0,0,17,0,0,29,benzyl alcohol,ethoxybenzene,OCc1ccccc1,CCOc1ccccc1
+417,benzyl alcohol__methoxybenzene,12,0,0,0,17,0,0,29,benzyl alcohol,methoxybenzene,OCc1ccccc1,COc1ccccc1
+419,2-phenylethanol__methoxybenzene,12,0,0,0,17,0,0,29,2-phenylethanol,methoxybenzene,OCCc1ccccc1,COc1ccccc1
+420,ethoxybenzene__3-phenyl-1-propanol,12,0,0,0,17,0,0,29,ethoxybenzene,3-phenyl-1-propanol,CCOc1ccccc1,OCCCc1ccccc1
+422,methoxybenzene__3-phenyl-1-propanol,12,0,0,0,17,0,0,29,methoxybenzene,3-phenyl-1-propanol,COc1ccccc1,OCCCc1ccccc1
+393,"1,2-butanediol__water",14,0,0,0,0,0,14,28,"1,2-butanediol",water,CCC(O)CO,O
+394,trimethylene glycol__water,14,0,0,0,0,0,14,28,trimethylene glycol,water,OCCCO,O
+395,"2,3-butanediol__water",14,0,0,0,0,0,14,28,"2,3-butanediol",water,CC(O)C(C)O,O
+396,"butane, 1,4-dihydroxy-__water",14,0,0,0,0,0,14,28,"butane, 1,4-dihydroxy-",water,OCCCCO,O
+397,"1,3-butanediol__water",14,0,0,0,0,0,14,28,"1,3-butanediol",water,CC(O)CCO,O
+418,"ethanol, 2-ethoxy-__water",12,0,16,0,0,0,0,28,"ethanol, 2-ethoxy-",water,CCOCCO,O
+440,"1,4-dioxane__water",10,0,18,0,0,0,0,28,"1,4-dioxane",water,C1COCCO1,O
+321,tetrole__n-hexane,27,0,0,0,0,0,0,27,tetrole,n-hexane,o1cccc1,CCCCCC
+322,"1,2-dimethylbenzene__hexane",27,0,0,0,0,0,0,27,"1,2-dimethylbenzene",hexane,Cc1ccccc1C,CCCCCC
+323,phenylmethane__tetrole,27,0,0,0,0,0,0,27,phenylmethane,tetrole,Cc1ccccc1,o1cccc1
+573,"benzene__1,3-dioxolane",0,0,27,0,0,0,0,27,benzene,"1,3-dioxolane",c1ccccc1,C1COCO1
+574,"cyclopentane__1,3-dioxolane",0,0,27,0,0,0,0,27,cyclopentane,"1,3-dioxolane",C1CCCC1,C1COCO1
+575,"cyclohexane__1,3-dioxolane",0,0,27,0,0,0,0,27,cyclohexane,"1,3-dioxolane",C1CCCCC1,C1COCO1
+400,ethylbenzene__octane,13,0,13,0,0,0,0,26,ethylbenzene,octane,CCc1ccccc1,CCCCCCCC
+403,toluene__cyclopentane,13,0,13,0,0,0,0,26,toluene,cyclopentane,Cc1ccccc1,C1CCCC1
+406,ethylbenzene__cyclopentane,13,0,13,0,0,0,0,26,ethylbenzene,cyclopentane,CCc1ccccc1,C1CCCC1
+407,ethylbenzene__nonane,13,0,13,0,0,0,0,26,ethylbenzene,nonane,CCc1ccccc1,CCCCCCCCC
+410,benzene__cyclopentane,13,0,13,0,0,0,0,26,benzene,cyclopentane,c1ccccc1,C1CCCC1
+339,n-propyl alcohol__water,25,0,0,0,0,0,0,25,n-propyl alcohol,water,CCCO,O
+340,"propan-1-ol__1,3-benzenediol",25,0,0,0,0,0,0,25,propan-1-ol,"1,3-benzenediol",CCCO,Oc1cccc(O)c1
+341,"butan-1-ol__1,3-benzenediol",25,0,0,0,0,0,0,25,butan-1-ol,"1,3-benzenediol",CCCCO,Oc1cccc(O)c1
+374,glycerol__ethanol,20,5,0,0,0,0,0,25,glycerol,ethanol,OCC(O)CO,CCO
+404,ethylene glycol__1-heptanol,13,0,12,0,0,0,0,25,ethylene glycol,1-heptanol,OCCO,CCCCCCCO
+343,methanol__toluene,24,0,0,0,0,0,0,24,methanol,toluene,CO,Cc1ccccc1
+345,2-ethoxyethanol__water,24,0,0,0,0,0,0,24,2-ethoxyethanol,water,CCOCCO,O
+347,2-n-butoxyethanol__water,24,0,0,0,0,0,0,24,2-n-butoxyethanol,water,CCCCOCCO,O
+348,D-(+)-arabitol__water,24,0,0,0,0,0,0,24,D-(+)-arabitol,water,OCC(O)C(O)C(O)CO,O
+413,isobutanol__water,12,0,12,0,0,0,0,24,isobutanol,water,CC(C)CO,O
+414,benzene__hexane,12,0,12,0,0,0,0,24,benzene,hexane,c1ccccc1,CCCCCC
+424,"ethane, 1,1'-oxybis-__1,3-dioxolane",11,0,12,0,0,0,0,23,"ethane, 1,1'-oxybis-","1,3-dioxolane",CCOCC,C1COCO1
+621,neohexane__tetrahydrofuran,0,0,0,0,23,0,0,23,neohexane,tetrahydrofuran,CCC(C)(C)C,C1CCOC1
+622,diisopropyl__tetrahydrofuran,0,0,0,0,23,0,0,23,diisopropyl,tetrahydrofuran,CC(C)C(C)C,C1CCOC1
+352,ethylene glycol__1-nonanol,22,0,0,0,0,0,0,22,ethylene glycol,1-nonanol,OCCO,CCCCCCCCCO
+353,benzene__methoxybenzene,22,0,0,0,0,0,0,22,benzene,methoxybenzene,c1ccccc1,COc1ccccc1
+355,methoxybenzene__butylbenzene,22,0,0,0,0,0,0,22,methoxybenzene,butylbenzene,COc1ccccc1,CCCCc1ccccc1
+356,benzene__toluene,22,0,0,0,0,0,0,22,benzene,toluene,c1ccccc1,Cc1ccccc1
+357,"1,3-dimethylbenzene__pentylcarbinol",22,0,0,0,0,0,0,22,"1,3-dimethylbenzene",pentylcarbinol,Cc1cccc(C)c1,CCCCCCO
+358,methoxybenzene__toluene,22,0,0,0,0,0,0,22,methoxybenzene,toluene,COc1ccccc1,Cc1ccccc1
+359,benzene__ethylbenzene,22,0,0,0,0,0,0,22,benzene,ethylbenzene,c1ccccc1,CCc1ccccc1
+360,heptane__cyclooctane,22,0,0,0,0,0,0,22,heptane,cyclooctane,CCCCCCC,C1CCCCCCC1
+361,ethylbenzene__methoxybenzene,22,0,0,0,0,0,0,22,ethylbenzene,methoxybenzene,CCc1ccccc1,COc1ccccc1
+362,1-propanol__1-heptanol,22,0,0,0,0,0,0,22,1-propanol,1-heptanol,CCCO,CCCCCCCO
+363,"1,2-dimethylbenzene__pentylcarbinol",22,0,0,0,0,0,0,22,"1,2-dimethylbenzene",pentylcarbinol,Cc1ccccc1C,CCCCCCO
+364,methoxybenzene__propylbenzene,22,0,0,0,0,0,0,22,methoxybenzene,propylbenzene,COc1ccccc1,CCCc1ccccc1
+365,1-heptanol__1-nonanol,22,0,0,0,0,0,0,22,1-heptanol,1-nonanol,CCCCCCCO,CCCCCCCCCO
+366,ethylbenzene__toluene,22,0,0,0,0,0,0,22,ethylbenzene,toluene,CCc1ccccc1,Cc1ccccc1
+367,1-propanol__1-pentanol,22,0,0,0,0,0,0,22,1-propanol,1-pentanol,CCCO,CCCCCO
+368,1-propanol__1-nonanol,22,0,0,0,0,0,0,22,1-propanol,1-nonanol,CCCO,CCCCCCCCCO
+369,1-pentanol__1-nonanol,22,0,0,0,0,0,0,22,1-pentanol,1-nonanol,CCCCCO,CCCCCCCCCO
+370,1-pentanol__1-heptanol,22,0,0,0,0,0,0,22,1-pentanol,1-heptanol,CCCCCO,CCCCCCCO
+416,2-ethyl-1-hexanol__ethylene glycol,12,0,10,0,0,0,0,22,2-ethyl-1-hexanol,ethylene glycol,CCCCC(CC)CO,OCCO
+425,"ethane, 1,1'-oxybis-__pentan-1-ol",11,0,11,0,0,0,0,22,"ethane, 1,1'-oxybis-",pentan-1-ol,CCOCC,CCCCCO
+426,"2-methoxyethanol__1,3-dioxolane",11,0,11,0,0,0,0,22,2-methoxyethanol,"1,3-dioxolane",COCCO,C1COCO1
+431,"pentan-1-ol__1,3-dioxolane",11,0,11,0,0,0,0,22,pentan-1-ol,"1,3-dioxolane",CCCCCO,C1COCO1
+432,"ethanol, 2-ethoxy-__1,3-dioxolane",11,0,11,0,0,0,0,22,"ethanol, 2-ethoxy-","1,3-dioxolane",CCOCCO,C1COCO1
+433,"2-butoxyethanol__1,3-dioxolane",11,0,11,0,0,0,0,22,2-butoxyethanol,"1,3-dioxolane",CCCCOCCO,C1COCO1
+584,benzene__2-methyltetrahydrofuran,0,0,11,0,11,0,0,22,benzene,2-methyltetrahydrofuran,c1ccccc1,CC1CCCO1
+434,isopropyl ether__toluene,11,0,0,0,10,0,0,21,isopropyl ether,toluene,CC(C)OC(C)C,Cc1ccccc1
+623,tetramethylene oxide__dibutyl ether,0,0,0,0,21,0,0,21,tetramethylene oxide,dibutyl ether,C1CCOC1,CCCCOCCCC
+375,"ethanol__1,3-benzenediol",20,0,0,0,0,0,0,20,ethanol,"1,3-benzenediol",CCO,Oc1cccc(O)c1
+438,ethanol__ethylene glycol,10,0,10,0,0,0,0,20,ethanol,ethylene glycol,CCO,OCCO
+624,"2,3-dimethylbutane__ether, dipropyl",0,0,0,0,20,0,0,20,"2,3-dimethylbutane","ether, dipropyl",CC(C)C(C)C,CCCOCCC
+625,"butane, 2,2-dimethyl-__butyl oxide",0,0,0,0,20,0,0,20,"butane, 2,2-dimethyl-",butyl oxide,CCC(C)(C)C,CCCCOCCCC
+626,dipropyl ether__dibutyl ether,0,0,0,0,20,0,0,20,dipropyl ether,dibutyl ether,CCCOCCC,CCCCOCCCC
+627,tetramethylene oxide__dipropyl ether,0,0,0,0,20,0,0,20,tetramethylene oxide,dipropyl ether,C1CCOC1,CCCOCCC
+628,"2,3-dimethylbutane__butyl oxide",0,0,0,0,20,0,0,20,"2,3-dimethylbutane",butyl oxide,CC(C)C(C)C,CCCCOCCCC
+629,methanol__dibutyl ether,0,0,0,0,20,0,0,20,methanol,dibutyl ether,CO,CCCCOCCCC
+376,2-methyl-1-propanol__2-methyl-1-butanol,19,0,0,0,0,0,0,19,2-methyl-1-propanol,2-methyl-1-butanol,CC(C)CO,CCC(C)CO
+380,2-methyl-1-propanol__3-methyl-1-butanol,19,0,0,0,0,0,0,19,2-methyl-1-propanol,3-methyl-1-butanol,CC(C)CO,CC(C)CCO
+381,1-propanol__tert-butyl ethyl ether,19,0,0,0,0,0,0,19,1-propanol,tert-butyl ethyl ether,CCCO,CCOC(C)(C)C
+382,1-pentanol__2-methyl-1-propanol,19,0,0,0,0,0,0,19,1-pentanol,2-methyl-1-propanol,CCCCCO,CC(C)CO
+630,1-methoxy-2-propanol__cyclohexane,0,0,0,0,19,0,0,19,1-methoxy-2-propanol,cyclohexane,COCC(C)O,C1CCCCC1
+631,"butane, 2,2-dimethyl-__ether, dipropyl",0,0,0,0,19,0,0,19,"butane, 2,2-dimethyl-","ether, dipropyl",CCC(C)(C)C,CCCOCCC
+632,cyclohexane__2-butoxyethanol,0,0,0,0,19,0,0,19,cyclohexane,2-butoxyethanol,C1CCCCC1,CCCCOCCO
+633,1-pentanol__decane,0,0,0,0,19,0,0,19,1-pentanol,decane,CCCCCO,CCCCCCCCCC
+634,methanol__methoxymethane,0,0,0,0,19,0,0,19,methanol,methoxymethane,CO,COC
+635,cyclohexane__5-oxanonane,0,0,0,0,19,0,0,19,cyclohexane,5-oxanonane,C1CCCCC1,CCCCOCCCC
+636,epoxypropane__2-methylpentane,0,0,0,0,19,0,0,19,epoxypropane,2-methylpentane,CC1CO1,CCCC(C)C
+637,1-propanol__methoxymethane,0,0,0,0,19,0,0,19,1-propanol,methoxymethane,CCCO,COC
+638,"octane__1,4-dioxane",0,0,0,0,19,0,0,19,octane,"1,4-dioxane",CCCCCCCC,C1COCCO1
+639,ethanol__methoxymethane,0,0,0,0,19,0,0,19,ethanol,methoxymethane,CCO,COC
+640,1-butanol__methoxymethane,0,0,0,0,19,0,0,19,1-butanol,methoxymethane,CCCCO,COC
+641,cyclohexane__dibutyl ether,0,0,0,0,19,0,0,19,cyclohexane,dibutyl ether,C1CCCCC1,CCCCOCCCC
+642,benzene__1-methoxy-2-propanol,0,0,0,0,19,0,0,19,benzene,1-methoxy-2-propanol,c1ccccc1,COCC(C)O
+643,benzene__2-butoxyethanol,0,0,0,0,19,0,0,19,benzene,2-butoxyethanol,c1ccccc1,CCCCOCCO
+644,ethanol__tetrahydropyran,0,0,0,0,19,0,0,19,ethanol,tetrahydropyran,CCO,C1CCOCC1
+384,ethane__toluene,18,0,0,0,0,0,0,18,ethane,toluene,CC,Cc1ccccc1
+385,"n-hexane__2,5-dimethylfuran",18,0,0,0,0,0,0,18,n-hexane,"2,5-dimethylfuran",CCCCCC,Cc1oc(C)cc1
+446,2-methyl-2-butanol__ethyl tert-pentyl ether,9,0,0,0,9,0,0,18,2-methyl-2-butanol,ethyl tert-pentyl ether,CCC(C)(C)O,CCOC(C)(C)CC
+448,butan-2-ol__ethyl tert-pentyl ether,9,0,0,0,9,0,0,18,butan-2-ol,ethyl tert-pentyl ether,CCC(C)O,CCOC(C)(C)CC
+450,1-butanol__ethyl tert-pentyl ether,9,0,0,0,9,0,0,18,1-butanol,ethyl tert-pentyl ether,CCCCO,CCOC(C)(C)CC
+645,hexane__cyclohexane,0,0,0,0,18,0,0,18,hexane,cyclohexane,CCCCCC,C1CCCCC1
+646,1-pentanol__nonane,0,0,0,0,18,0,0,18,1-pentanol,nonane,CCCCCO,CCCCCCCCC
+647,1-pentanol__hexane,0,0,0,0,18,0,0,18,1-pentanol,hexane,CCCCCO,CCCCCC
+648,"benzyl alcohol__3,6-dioxa-1-octanol",0,0,0,0,17,0,0,17,benzyl alcohol,"3,6-dioxa-1-octanol",OCc1ccccc1,CCOCCOCCO
+649,benzyl alcohol__dibutyl ether,0,0,0,0,17,0,0,17,benzyl alcohol,dibutyl ether,OCc1ccccc1,CCCCOCCCC
+650,"benzyl alcohol__1,2-dimethoxyethane",0,0,0,0,17,0,0,17,benzyl alcohol,"1,2-dimethoxyethane",OCc1ccccc1,COCCOC
+651,"benzyl alcohol__ethanol, 2-ethoxy-",0,0,0,0,17,0,0,17,benzyl alcohol,"ethanol, 2-ethoxy-",OCc1ccccc1,CCOCCO
+652,1-propanol__decane,0,0,0,0,17,0,0,17,1-propanol,decane,CCCO,CCCCCCCCCC
+653,2-methyl-1-propanol__1-methyl-1-(1-methylethoxy)ethane,0,0,0,0,17,0,0,17,2-methyl-1-propanol,1-methyl-1-(1-methylethoxy)ethane,CC(C)CO,CC(C)OC(C)C
+654,"benzyl alcohol__3,6-dioxaoctane",0,0,0,0,17,0,0,17,benzyl alcohol,"3,6-dioxaoctane",OCc1ccccc1,CCOCCOCC
+388,methanol__dioxane,16,0,0,0,0,0,0,16,methanol,dioxane,CO,C1COCCO1
+466,tert-pentyl alcohol__water,0,16,0,0,0,0,0,16,tert-pentyl alcohol,water,CCC(C)(C)O,O
+576,2-methoxyethanol__water,0,0,16,0,0,0,0,16,2-methoxyethanol,water,COCCO,O
+655,1-propanol__heptane,0,0,0,0,16,0,0,16,1-propanol,heptane,CCCO,CCCCCCC
+392,methane__pentane,15,0,0,0,0,0,0,15,methane,pentane,C,CCCCC
+467,"1-butanol, 3-methyl-__water",0,15,0,0,0,0,0,15,"1-butanol, 3-methyl-",water,CC(C)CCO,O
+468,2-methyl-1-butanol__water,0,15,0,0,0,0,0,15,2-methyl-1-butanol,water,CCC(C)CO,O
+656,ethanol__nonane,0,0,0,0,15,0,0,15,ethanol,nonane,CCO,CCCCCCCCC
+657,ethanol__decane,0,0,0,0,15,0,0,15,ethanol,decane,CCO,CCCCCCCCCC
+658,butan-2-ol__cyclohexyl alcohol,0,0,0,0,15,0,0,15,butan-2-ol,cyclohexyl alcohol,CCC(C)O,OC1CCCCC1
+659,1-propanol__nonane,0,0,0,0,15,0,0,15,1-propanol,nonane,CCCO,CCCCCCCCC
+660,"1,2-dimethylbenzene__dibutyl ether",0,0,0,0,15,0,0,15,"1,2-dimethylbenzene",dibutyl ether,Cc1ccccc1C,CCCCOCCCC
+398,2-ethyl-1-hexanol__1-nonanol,14,0,0,0,0,0,0,14,2-ethyl-1-hexanol,1-nonanol,CCCCC(CC)CO,CCCCCCCCCO
+661,benzene__2-methyl-1-propanol,0,0,0,0,14,0,0,14,benzene,2-methyl-1-propanol,c1ccccc1,CC(C)CO
+401,ethanol__oxane,13,0,0,0,0,0,0,13,ethanol,oxane,CCO,C1CCOCC1
+405,1-octanol__2-octanol,13,0,0,0,0,0,0,13,1-octanol,2-octanol,CCCCCCCCO,CCCCCCC(C)O
+409,anisole__phenol,13,0,0,0,0,0,0,13,anisole,phenol,COc1ccccc1,Oc1ccccc1
+411,2-ethyl-1-hexanol__1-heptanol,13,0,0,0,0,0,0,13,2-ethyl-1-hexanol,1-heptanol,CCCCC(CC)CO,CCCCCCCO
+469,pentan-2-ol__water,0,13,0,0,0,0,0,13,pentan-2-ol,water,CCCC(C)O,O
+582,"1-butanol__1,2-butanediol",0,0,13,0,0,0,0,13,1-butanol,"1,2-butanediol",CCCCO,CCC(O)CO
+662,1-butanol__1-methyl-1-(1-methylethoxy)ethane,0,0,0,0,13,0,0,13,1-butanol,1-methyl-1-(1-methylethoxy)ethane,CCCCO,CC(C)OC(C)C
+663,n-butyl alcohol__cyclohexyl alcohol,0,0,0,0,13,0,0,13,n-butyl alcohol,cyclohexyl alcohol,CCCCO,OC1CCCCC1
+415,"1,3-dioxolane__water",12,0,0,0,0,0,0,12,"1,3-dioxolane",water,C1COCO1,O
+421,2-propanol__methane,12,0,0,0,0,0,0,12,2-propanol,methane,CC(C)O,C
+423,methanol__tetrahydrofuran,12,0,0,0,0,0,0,12,methanol,tetrahydrofuran,CO,C1CCOC1
+664,1-methyl-1-(1-methylethoxy)ethane__heptane,0,0,0,0,12,0,0,12,1-methyl-1-(1-methylethoxy)ethane,heptane,CC(C)OC(C)C,CCCCCCC
+427,benzene__2-methoxyethanol,11,0,0,0,0,0,0,11,benzene,2-methoxyethanol,c1ccccc1,COCCO
+428,benzene__methyl tert-butyl ether,11,0,0,0,0,0,0,11,benzene,methyl tert-butyl ether,c1ccccc1,COC(C)(C)C
+429,benzene__dibutyl ether,11,0,0,0,0,0,0,11,benzene,dibutyl ether,c1ccccc1,CCCCOCCCC
+430,methanol__anisol,11,0,0,0,0,0,0,11,methanol,anisol,CO,COc1ccccc1
+435,toluene__2-methoxyethanol,11,0,0,0,0,0,0,11,toluene,2-methoxyethanol,Cc1ccccc1,COCCO
+436,p-xylene__2-methoxyethanol,11,0,0,0,0,0,0,11,p-xylene,2-methoxyethanol,Cc1ccc(C)cc1,COCCO
+437,ethanol__dibutyl ether,11,0,0,0,0,0,0,11,ethanol,dibutyl ether,CCO,CCCCOCCCC
+470,3-pentanol__water,0,11,0,0,0,0,0,11,3-pentanol,water,CCC(O)CC,O
+665,"1,2-propanediol__methanol",0,0,0,0,11,0,0,11,"1,2-propanediol",methanol,CC(O)CO,CO
+666,propyl alcohol__cyclohexyl alcohol,0,0,0,0,11,0,0,11,propyl alcohol,cyclohexyl alcohol,CCCO,OC1CCCCC1
+667,methanol__.alpha.-toluenol,0,0,0,0,11,0,0,11,methanol,.alpha.-toluenol,CO,OCc1ccccc1
+668,tetrahydrofuran__nonane,0,0,0,0,11,0,0,11,tetrahydrofuran,nonane,C1CCOC1,CCCCCCCCC
+669,1-hexanol__cyclopentane,0,0,0,0,11,0,0,11,1-hexanol,cyclopentane,CCCCCCO,C1CCCC1
+670,"isopropyl ether__1,3-dimethylbenzene",0,0,0,0,11,0,0,11,isopropyl ether,"1,3-dimethylbenzene",CC(C)OC(C)C,Cc1cccc(C)c1
+439,1-pentanol__2-ethyl-1-hexanol,10,0,0,0,0,0,0,10,1-pentanol,2-ethyl-1-hexanol,CCCCCO,CCCCC(CC)CO
+441,phenol__1-octanol,10,0,0,0,0,0,0,10,phenol,1-octanol,Oc1ccccc1,CCCCCCCCO
+442,"2-ethyl-1-hexanol__2,3-butanediol",10,0,0,0,0,0,0,10,2-ethyl-1-hexanol,"2,3-butanediol",CCCCC(CC)CO,CC(O)C(C)O
+443,2-propanol__ethane,10,0,0,0,0,0,0,10,2-propanol,ethane,CC(C)O,CC
+461,naphthalene__heptane,5,0,5,0,0,0,0,10,naphthalene,heptane,c1ccc2ccccc2c1,CCCCCCC
+462,naphthalene__cyclohexane,5,0,5,0,0,0,0,10,naphthalene,cyclohexane,c1ccc2ccccc2c1,C1CCCCC1
+471,3-methyl-2-butanol__water,0,10,0,0,0,0,0,10,3-methyl-2-butanol,water,CC(C)C(C)O,O
+585,isopropyl ether__hexane,0,0,10,0,0,0,0,10,isopropyl ether,hexane,CC(C)OC(C)C,CCCCCC
+586,isopropyl ether__heptane,0,0,10,0,0,0,0,10,isopropyl ether,heptane,CC(C)OC(C)C,CCCCCCC
+587,isopropyl ether__octane,0,0,10,0,0,0,0,10,isopropyl ether,octane,CC(C)OC(C)C,CCCCCCCC
+671,"1,2-propanediol__1-hexanol",0,0,0,0,10,0,0,10,"1,2-propanediol",1-hexanol,CC(O)CO,CCCCCCO
+672,pentan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,pentan-1-ol,tert-pentyl alcohol,CCCCCO,CCC(C)(C)O
+673,ethanol__cyclohexyl alcohol,0,0,0,0,10,0,0,10,ethanol,cyclohexyl alcohol,CCO,OC1CCCCC1
+674,ethanol__.alpha.-toluenol,0,0,0,0,10,0,0,10,ethanol,.alpha.-toluenol,CCO,OCc1ccccc1
+675,1-nonanol__cyclopentane,0,0,0,0,10,0,0,10,1-nonanol,cyclopentane,CCCCCCCCCO,C1CCCC1
+676,ethanol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,ethanol,tert-pentyl alcohol,CCO,CCC(C)(C)O
+677,butan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,butan-1-ol,tert-pentyl alcohol,CCCCO,CCC(C)(C)O
+678,"1,2-propanediol__1-pentanol",0,0,0,0,10,0,0,10,"1,2-propanediol",1-pentanol,CC(O)CO,CCCCCO
+679,"1,2-propanediol__ethanol",0,0,0,0,10,0,0,10,"1,2-propanediol",ethanol,CC(O)CO,CCO
+680,"1,2-propanediol__1-butanol",0,0,0,0,10,0,0,10,"1,2-propanediol",1-butanol,CC(O)CO,CCCCO
+681,1-octanol__cyclopentane,0,0,0,0,10,0,0,10,1-octanol,cyclopentane,CCCCCCCCO,C1CCCC1
+682,cyclohexane__1-heptanol,0,0,0,0,10,0,0,10,cyclohexane,1-heptanol,C1CCCCC1,CCCCCCCO
+683,propan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,propan-1-ol,tert-pentyl alcohol,CCCO,CCC(C)(C)O
+684,methanol__cyclohexyl alcohol,0,0,0,0,10,0,0,10,methanol,cyclohexyl alcohol,CO,OC1CCCCC1
+685,"1,2-propanediol__1-propanol",0,0,0,0,10,0,0,10,"1,2-propanediol",1-propanol,CC(O)CO,CCCO
+686,methanol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,methanol,tert-pentyl alcohol,CO,CCC(C)(C)O
+444,ethane__pentane,9,0,0,0,0,0,0,9,ethane,pentane,CC,CCCCC
+445,(RS)-2-butanol__water,9,0,0,0,0,0,0,9,(RS)-2-butanol,water,CCC(C)O,O
+447,"2-ethyl-1-hexanol__butane, 1,4-dihydroxy-",9,0,0,0,0,0,0,9,2-ethyl-1-hexanol,"butane, 1,4-dihydroxy-",CCCCC(CC)CO,OCCCCO
+449,cyclohexane__1-octanol,9,0,0,0,0,0,0,9,cyclohexane,1-octanol,C1CCCCC1,CCCCCCCCO
+451,isooctane__methyl tert-butyl ether,9,0,0,0,0,0,0,9,isooctane,methyl tert-butyl ether,CCCCCC(C)C,COC(C)(C)C
+472,furan__water,0,9,0,0,0,0,0,9,furan,water,o1cccc1,O
+588,isopropyl ether__cyclohexane,0,0,9,0,0,0,0,9,isopropyl ether,cyclohexane,CC(C)OC(C)C,C1CCCCC1
+589,isopropyl ether__tetralin,0,0,9,0,0,0,0,9,isopropyl ether,tetralin,CC(C)OC(C)C,C1CCc2ccccc2C1
+590,benzene__isopropyl ether,0,0,9,0,0,0,0,9,benzene,isopropyl ether,c1ccccc1,CC(C)OC(C)C
+591,decahydronaphthalene__isopropyl ether,0,0,9,0,0,0,0,9,decahydronaphthalene,isopropyl ether,C1CCC2CCCCC2C1,CC(C)OC(C)C
+687,propan-1-ol__.alpha.-toluenol,0,0,0,0,9,0,0,9,propan-1-ol,.alpha.-toluenol,CCCO,OCc1ccccc1
+688,1-pentanol__tetrahydropyran,0,0,0,0,9,0,0,9,1-pentanol,tetrahydropyran,CCCCCO,C1CCOCC1
+689,butan-1-ol__.alpha.-toluenol,0,0,0,0,9,0,0,9,butan-1-ol,.alpha.-toluenol,CCCCO,OCc1ccccc1
+690,tetrahydropyran__decane,0,0,0,0,9,0,0,9,tetrahydropyran,decane,C1CCOCC1,CCCCCCCCCC
+691,"1,4-dioxane__tetrahydropyran",0,0,0,0,9,0,0,9,"1,4-dioxane",tetrahydropyran,C1COCCO1,C1CCOCC1
+692,.alpha.-toluenol__pentylcarbinol,0,0,0,0,9,0,0,9,.alpha.-toluenol,pentylcarbinol,OCc1ccccc1,CCCCCCO
+693,cyclohexane__1-nonanol,0,0,0,0,9,0,0,9,cyclohexane,1-nonanol,C1CCCCC1,CCCCCCCCCO
+694,2-propanol__cyclohexyl alcohol,0,0,0,0,9,0,0,9,2-propanol,cyclohexyl alcohol,CC(C)O,OC1CCCCC1
+695,pentan-1-ol__.alpha.-toluenol,0,0,0,0,9,0,0,9,pentan-1-ol,.alpha.-toluenol,CCCCCO,OCc1ccccc1
+696,tetrahydropyran__1-nonanol,0,0,0,0,9,0,0,9,tetrahydropyran,1-nonanol,C1CCOCC1,CCCCCCCCCO
+452,"3-oxa-1,5-pentanediol__3,6-dioxa-1,8-octanediol",8,0,0,0,0,0,0,8,"3-oxa-1,5-pentanediol","3,6-dioxa-1,8-octanediol",OCCOCCO,OCCOCCOCCO
+453,isopropyl ether__isooctane,8,0,0,0,0,0,0,8,isopropyl ether,isooctane,CC(C)OC(C)C,CCCCCC(C)C
+454,"1,2-ethanediol__3-oxa-1,5-pentanediol",8,0,0,0,0,0,0,8,"1,2-ethanediol","3-oxa-1,5-pentanediol",OCCO,OCCOCCO
+455,ethylene glycol__bis(2-hydroxyethyl) ether,8,0,0,0,0,0,0,8,ethylene glycol,bis(2-hydroxyethyl) ether,OCCO,OCCOCCO
+456,"1,2-ethanediol__3,6-dioxa-1,8-octanediol",8,0,0,0,0,0,0,8,"1,2-ethanediol","3,6-dioxa-1,8-octanediol",OCCO,OCCOCCOCCO
+457,methane__butane,6,0,0,0,0,0,0,6,methane,butane,C,CCCC
+458,"bis(2-hydroxyethyl) ether__3,6-dioxa-1,8-octanediol",5,0,0,0,0,0,0,5,bis(2-hydroxyethyl) ether,"3,6-dioxa-1,8-octanediol",OCCOCCO,OCCOCCOCCO
+459,"ethylene glycol__3,6-dioxa-1,8-octanediol",5,0,0,0,0,0,0,5,ethylene glycol,"3,6-dioxa-1,8-octanediol",OCCO,OCCOCCOCCO
+460,methanol__2-methoxyethanol,5,0,0,0,0,0,0,5,methanol,2-methoxyethanol,CO,COCCO
+473,toluene__methoxymethane,0,5,0,0,0,0,0,5,toluene,methoxymethane,Cc1ccccc1,COC
+474,"1,4-dimethylbenzene__butane",0,5,0,0,0,0,0,5,"1,4-dimethylbenzene",butane,Cc1ccc(C)cc1,CCCC
+475,"decane__1,3-propanediol",0,5,0,0,0,0,0,5,decane,"1,3-propanediol",CCCCCCCCCC,OCCCO
+476,"propane__1,4-dimethylbenzene",0,5,0,0,0,0,0,5,propane,"1,4-dimethylbenzene",CCC,Cc1ccc(C)cc1
+477,"1,2-dimethylbenzene__methoxymethane",0,5,0,0,0,0,0,5,"1,2-dimethylbenzene",methoxymethane,Cc1ccccc1C,COC
+478,"octane__1,3-propanediol",0,5,0,0,0,0,0,5,octane,"1,3-propanediol",CCCCCCCC,OCCCO
+479,"2-methylpropane__1,4-dimethylbenzene",0,5,0,0,0,0,0,5,2-methylpropane,"1,4-dimethylbenzene",CC(C)C,Cc1ccc(C)cc1
+480,"1,4-dimethylbenzene__methoxymethane",0,5,0,0,0,0,0,5,"1,4-dimethylbenzene",methoxymethane,Cc1ccc(C)cc1,COC
+463,methane__ethane,4,0,0,0,0,0,0,4,methane,ethane,C,CC
+481,2-methylpropane__toluene,0,4,0,0,0,0,0,4,2-methylpropane,toluene,CC(C)C,Cc1ccccc1
+482,"butane, 2-ethoxy-2-methyl-__water",0,4,0,0,0,0,0,4,"butane, 2-ethoxy-2-methyl-",water,CCOC(C)(C)CC,O
+483,"2-methylpropane__1,2-dimethylbenzene",0,4,0,0,0,0,0,4,2-methylpropane,"1,2-dimethylbenzene",CC(C)C,Cc1ccccc1C
+484,benzene__methoxymethane,0,4,0,0,0,0,0,4,benzene,methoxymethane,c1ccccc1,COC
+485,"propane__1,2-dimethylbenzene",0,4,0,0,0,0,0,4,propane,"1,2-dimethylbenzene",CCC,Cc1ccccc1C
+486,butane__toluene,0,4,0,0,0,0,0,4,butane,toluene,CCCC,Cc1ccccc1
+487,benzene__propane,0,4,0,0,0,0,0,4,benzene,propane,c1ccccc1,CCC
+488,"2-methylpropane__1,3-dimethylbenzene",0,4,0,0,0,0,0,4,2-methylpropane,"1,3-dimethylbenzene",CC(C)C,Cc1cccc(C)c1
+489,"1,3-dimethylbenzene__methoxymethane",0,4,0,0,0,0,0,4,"1,3-dimethylbenzene",methoxymethane,Cc1cccc(C)c1,COC
+490,toluene__water,0,4,0,0,0,0,0,4,toluene,water,Cc1ccccc1,O
+491,methyl tert-butyl ether__water,0,4,0,0,0,0,0,4,methyl tert-butyl ether,water,COC(C)(C)C,O
+492,"propane__1,3-dimethylbenzene",0,4,0,0,0,0,0,4,propane,"1,3-dimethylbenzene",CCC,Cc1cccc(C)c1
+493,"1,2-dimethylbenzene__butane",0,4,0,0,0,0,0,4,"1,2-dimethylbenzene",butane,Cc1ccccc1C,CCCC
+494,tert-amyl methyl ether__water,0,4,0,0,0,0,0,4,tert-amyl methyl ether,water,CCC(C)(C)OC,O
+495,benzene__2-methylpropane,0,4,0,0,0,0,0,4,benzene,2-methylpropane,c1ccccc1,CC(C)C
+496,tert-butyl ethyl ether__water,0,4,0,0,0,0,0,4,tert-butyl ethyl ether,water,CCOC(C)(C)C,O
+497,propane__toluene,0,4,0,0,0,0,0,4,propane,toluene,CCC,Cc1ccccc1
+498,benzene__butane,0,4,0,0,0,0,0,4,benzene,butane,c1ccccc1,CCCC
+499,"butane__1,3-dimethylbenzene",0,4,0,0,0,0,0,4,butane,"1,3-dimethylbenzene",CCCC,Cc1cccc(C)c1
+464,methanol__ethane,3,0,0,0,0,0,0,3,methanol,ethane,CO,CC
+500,diethylene glycol__n-nonane,0,3,0,0,0,0,0,3,diethylene glycol,n-nonane,OCCOCCO,CCCCCCCCC
+501,triethylene glycol__n-heptane,0,3,0,0,0,0,0,3,triethylene glycol,n-heptane,OCCOCCOCCO,CCCCCCC
+502,n-octane__triethylene glycol,0,3,0,0,0,0,0,3,n-octane,triethylene glycol,CCCCCCCC,OCCOCCOCCO
+503,n-nonane__triethylene glycol,0,3,0,0,0,0,0,3,n-nonane,triethylene glycol,CCCCCCCCC,OCCOCCOCCO
+504,triethylene glycol__cycloheptane,0,3,0,0,0,0,0,3,triethylene glycol,cycloheptane,OCCOCCOCCO,C1CCCCCC1
+505,2-propanol__triethylene glycol,0,3,0,0,0,0,0,3,2-propanol,triethylene glycol,CC(C)O,OCCOCCOCCO
+506,ethanol__triethylene glycol,0,3,0,0,0,0,0,3,ethanol,triethylene glycol,CCO,OCCOCCOCCO
+507,diethylene glycol__cycloheptane,0,3,0,0,0,0,0,3,diethylene glycol,cycloheptane,OCCOCCO,C1CCCCCC1
+508,n-hexane__diethylene glycol,0,3,0,0,0,0,0,3,n-hexane,diethylene glycol,CCCCCC,OCCOCCO
+509,diethylene glycol__cyclopentane,0,3,0,0,0,0,0,3,diethylene glycol,cyclopentane,OCCOCCO,C1CCCC1
+510,cyclohexane__diethylene glycol,0,3,0,0,0,0,0,3,cyclohexane,diethylene glycol,C1CCCCC1,OCCOCCO
+511,cyclohexane__triethylene glycol,0,3,0,0,0,0,0,3,cyclohexane,triethylene glycol,C1CCCCC1,OCCOCCOCCO
+512,2-propanol__diethylene glycol,0,3,0,0,0,0,0,3,2-propanol,diethylene glycol,CC(C)O,OCCOCCO
+513,benzene__triethylene glycol,0,3,0,0,0,0,0,3,benzene,triethylene glycol,c1ccccc1,OCCOCCOCCO
+514,ethylbenzene__triethylene glycol,0,3,0,0,0,0,0,3,ethylbenzene,triethylene glycol,CCc1ccccc1,OCCOCCOCCO
+515,ethylbenzene__diethylene glycol,0,3,0,0,0,0,0,3,ethylbenzene,diethylene glycol,CCc1ccccc1,OCCOCCO
+516,1-propanol__triethylene glycol,0,3,0,0,0,0,0,3,1-propanol,triethylene glycol,CCCO,OCCOCCOCCO
+517,diethylene glycol__cyclooctane,0,3,0,0,0,0,0,3,diethylene glycol,cyclooctane,OCCOCCO,C1CCCCCCC1
+518,toluene__diethylene glycol,0,3,0,0,0,0,0,3,toluene,diethylene glycol,Cc1ccccc1,OCCOCCO
+519,n-pentane__triethylene glycol,0,3,0,0,0,0,0,3,n-pentane,triethylene glycol,CCCCC,OCCOCCOCCO
+520,diethylene glycol__n-heptane,0,3,0,0,0,0,0,3,diethylene glycol,n-heptane,OCCOCCO,CCCCCCC
+521,"hexane__1,3-propanediol",0,3,0,0,0,0,0,3,hexane,"1,3-propanediol",CCCCCC,OCCCO
+522,n-pentane__diethylene glycol,0,3,0,0,0,0,0,3,n-pentane,diethylene glycol,CCCCC,OCCOCCO
+523,methanol__diethylene glycol,0,3,0,0,0,0,0,3,methanol,diethylene glycol,CO,OCCOCCO
+524,1-propanol__diethylene glycol,0,3,0,0,0,0,0,3,1-propanol,diethylene glycol,CCCO,OCCOCCO
+525,triethylene glycol__cyclooctane,0,3,0,0,0,0,0,3,triethylene glycol,cyclooctane,OCCOCCOCCO,C1CCCCCCC1
+526,n-hexane__triethylene glycol,0,3,0,0,0,0,0,3,n-hexane,triethylene glycol,CCCCCC,OCCOCCOCCO
+527,triethylene glycol__cyclopentane,0,3,0,0,0,0,0,3,triethylene glycol,cyclopentane,OCCOCCOCCO,C1CCCC1
+528,"1,2-ethanediol__hexane",0,3,0,0,0,0,0,3,"1,2-ethanediol",hexane,OCCO,CCCCCC
+529,toluene__triethylene glycol,0,3,0,0,0,0,0,3,toluene,triethylene glycol,Cc1ccccc1,OCCOCCOCCO
+530,diethylene glycol__n-octane,0,3,0,0,0,0,0,3,diethylene glycol,n-octane,OCCOCCO,CCCCCCCC
+531,"1,2-ethanediol__decane",0,3,0,0,0,0,0,3,"1,2-ethanediol",decane,OCCO,CCCCCCCCCC
+532,ethanol__diethylene glycol,0,3,0,0,0,0,0,3,ethanol,diethylene glycol,CCO,OCCOCCO
+533,benzene__diethylene glycol,0,3,0,0,0,0,0,3,benzene,diethylene glycol,c1ccccc1,OCCOCCO
+534,methanol__triethylene glycol,0,2,0,0,0,0,0,2,methanol,triethylene glycol,CO,OCCOCCOCCO
+535,2-methylphenol__nonane,0,2,0,0,0,0,0,2,2-methylphenol,nonane,Cc1ccccc1O,CCCCCCCCC
+536,3-methylphenol__nonane,0,2,0,0,0,0,0,2,3-methylphenol,nonane,Cc1cccc(O)c1,CCCCCCCCC
+465,glycidol__water,1,0,0,0,0,0,0,1,glycidol,water,OCC1CO1,O
+537,methyl cellosolve__n-decane,0,1,0,0,0,0,0,1,methyl cellosolve,n-decane,COCCO,CCCCCCCCCC
+538,methylcyclopentane__methyl cellosolve,0,1,0,0,0,0,0,1,methylcyclopentane,methyl cellosolve,CC1CCCC1,COCCO
+539,propylene glycol__n-octane,0,1,0,0,0,0,0,1,propylene glycol,n-octane,CC(O)CO,CCCCCCCC
+540,methyl cellosolve__cyclohexane,0,1,0,0,0,0,0,1,methyl cellosolve,cyclohexane,COCCO,C1CCCCC1
+541,methyl cellosolve__cyclooctane,0,1,0,0,0,0,0,1,methyl cellosolve,cyclooctane,COCCO,C1CCCCCCC1
+542,2-methylphenol__decane,0,1,0,0,0,0,0,1,2-methylphenol,decane,Cc1ccccc1O,CCCCCCCCCC
+543,methylcyclohexane__methyl cellosolve,0,1,0,0,0,0,0,1,methylcyclohexane,methyl cellosolve,CC1CCCCC1,COCCO
+544,benzene__methyl cellosolve,0,1,0,0,0,0,0,1,benzene,methyl cellosolve,c1ccccc1,COCCO
+545,m-xylene__methyl cellosolve,0,1,0,0,0,0,0,1,m-xylene,methyl cellosolve,Cc1cccc(C)c1,COCCO
+546,propylene glycol__toluene,0,1,0,0,0,0,0,1,propylene glycol,toluene,CC(O)CO,Cc1ccccc1
+547,propylene glycol__benzene,0,1,0,0,0,0,0,1,propylene glycol,benzene,CC(O)CO,c1ccccc1
+548,o-xylene__methyl cellosolve,0,1,0,0,0,0,0,1,o-xylene,methyl cellosolve,Cc1ccccc1C,COCCO
+549,propylene glycol__ethylbenzene,0,1,0,0,0,0,0,1,propylene glycol,ethylbenzene,CC(O)CO,CCc1ccccc1
+550,propylene glycol__m-xylene,0,1,0,0,0,0,0,1,propylene glycol,m-xylene,CC(O)CO,Cc1cccc(C)c1
+551,propylene glycol__naphthalene,0,1,0,0,0,0,0,1,propylene glycol,naphthalene,CC(O)CO,c1ccc2ccccc2c1
+552,3-methylphenol__decane,0,1,0,0,0,0,0,1,3-methylphenol,decane,Cc1cccc(O)c1,CCCCCCCCCC
+553,p-cymene__methyl cellosolve,0,1,0,0,0,0,0,1,p-cymene,methyl cellosolve,CC(C)c1ccc(C)cc1,COCCO
+554,toluene__methyl cellosolve,0,1,0,0,0,0,0,1,toluene,methyl cellosolve,Cc1ccccc1,COCCO
+555,naphthalene__methyl cellosolve,0,1,0,0,0,0,0,1,naphthalene,methyl cellosolve,c1ccc2ccccc2c1,COCCO
+556,propylene glycol__n-heptane,0,1,0,0,0,0,0,1,propylene glycol,n-heptane,CC(O)CO,CCCCCCC
+557,ethylbenzene__methyl cellosolve,0,1,0,0,0,0,0,1,ethylbenzene,methyl cellosolve,CCc1ccccc1,COCCO
+558,p-xylene__methyl cellosolve,0,1,0,0,0,0,0,1,p-xylene,methyl cellosolve,Cc1ccc(C)cc1,COCCO
+559,methyl cellosolve__n-heptane,0,1,0,0,0,0,0,1,methyl cellosolve,n-heptane,COCCO,CCCCCCC
+560,methyl cellosolve__n-hexane,0,1,0,0,0,0,0,1,methyl cellosolve,n-hexane,COCCO,CCCCCC
+561,propylene glycol__n-hexane,0,1,0,0,0,0,0,1,propylene glycol,n-hexane,CC(O)CO,CCCCCC
+562,methyl cellosolve__n-nonane,0,1,0,0,0,0,0,1,methyl cellosolve,n-nonane,COCCO,CCCCCCCCC
+563,propylene glycol__o-xylene,0,1,0,0,0,0,0,1,propylene glycol,o-xylene,CC(O)CO,Cc1ccccc1C
+564,propylene glycol__p-xylene,0,1,0,0,0,0,0,1,propylene glycol,p-xylene,CC(O)CO,Cc1ccc(C)cc1
+565,methyl cellosolve__n-octane,0,1,0,0,0,0,0,1,methyl cellosolve,n-octane,COCCO,CCCCCCCC

--- a/Initial Molecule Choices/mix_counts_diverse.csv
+++ b/Initial Molecule Choices/mix_counts_diverse.csv
@@ -1,0 +1,193 @@
+,Mixture,Mixture Count dens binary,Mixture Count actcoeff binary,Mixture Count sos binary,Mixture Count dielec binary,Mixture Count eme binary,Mixture Count emcp binary,Mixture Count emv binary,Mixture Count all,x1,x2,SMILES1,SMILES2
+1,2-propanol__water,1012,0,0,0,45,0,0,1057,2-propanol,water,CC(C)O,O
+4,ethanol__water,712,0,20,0,83,0,0,815,ethanol,water,CCO,O
+6,ethanol__methylcyclohexane,753,0,11,0,0,0,0,764,ethanol,methylcyclohexane,CCO,CC1CCCCC1
+10,ethanol__heptane,708,0,39,0,0,0,0,747,ethanol,heptane,CCO,CCCCCCC
+11,2-methyl-2-propanol__water,636,0,6,0,0,0,0,642,2-methyl-2-propanol,water,CC(C)(C)O,O
+12,1-butanol__cyclohexane,501,0,51,0,38,0,0,590,1-butanol,cyclohexane,CCCCO,C1CCCCC1
+13,tert-pentyl alcohol__heptane,102,0,450,0,0,0,0,552,tert-pentyl alcohol,heptane,CCC(C)(C)O,CCCCCCC
+15,1-propoxy-2-propanol__water,318,0,145,0,0,0,0,463,1-propoxy-2-propanol,water,CCCOCC(C)O,O
+23,methanol__water,212,0,12,0,140,0,0,364,methanol,water,CO,O
+24,tert-butanol__water,360,0,0,0,0,0,0,360,tert-butanol,water,CC(C)(C)O,O
+27,n-butyl alcohol__2-methylheptane,324,0,0,0,0,0,0,324,n-butyl alcohol,2-methylheptane,CCCCO,CCCCCC(C)C
+42,ethanol__methanol,63,0,0,105,76,0,0,244,ethanol,methanol,CCO,CO
+44,tetrahydrofuran__water,220,0,20,0,0,0,0,240,tetrahydrofuran,water,C1CCOC1,O
+49,neopentyl alcohol__water,213,0,0,0,0,0,0,213,neopentyl alcohol,water,CC(C)(C)CO,O
+51,"1-butanol__2,2,4-trimethylpentane",93,0,80,0,38,0,0,211,1-butanol,"2,2,4-trimethylpentane",CCCCO,CC(C)CC(C)(C)C
+52,"2-methyl-1,3-propanediol__water",209,0,0,0,0,0,0,209,"2-methyl-1,3-propanediol",water,CC(CO)CO,O
+57,1-propanol__water,172,0,27,0,0,0,0,199,1-propanol,water,CCCO,O
+65,1-butanol__hexane,60,0,60,0,23,0,31,174,1-butanol,hexane,CCCCO,CCCCCC
+69,"ethanol__2,2,4-trimethylpentane",150,0,0,0,19,0,0,169,ethanol,"2,2,4-trimethylpentane",CCO,CC(C)CC(C)(C)C
+71,2-propanol__cyclohexane,78,0,78,0,9,0,0,165,2-propanol,cyclohexane,CC(C)O,C1CCCCC1
+74,propane__butane,157,0,0,0,0,0,0,157,propane,butane,CCC,CCCC
+76,"2,2-dimethyl-1,3-propanediol__water",156,0,0,0,0,0,0,156,"2,2-dimethyl-1,3-propanediol",water,CC(C)(CO)CO,O
+79,ethanol__cyclohexane,111,0,39,0,0,0,0,150,ethanol,cyclohexane,CCO,C1CCCCC1
+80,hexane__heptane,149,0,0,0,0,0,0,149,hexane,heptane,CCCCCC,CCCCCCC
+84,ethanol__isooctane,72,0,72,0,0,0,0,144,ethanol,isooctane,CCO,CCCCCC(C)C
+97,"3-methylpentane-1,5-diol__water",138,0,0,0,0,0,0,138,"3-methylpentane-1,5-diol",water,CC(CCO)CCO,O
+102,ethanol__2-methyl-1-butanol,116,0,18,0,0,0,0,134,ethanol,2-methyl-1-butanol,CCO,CCC(C)CO
+108,1-propanol__tert-butanol,66,0,66,0,0,0,0,132,1-propanol,tert-butanol,CCCO,CC(C)(C)O
+110,2-propanol__tert-butanol,66,0,66,0,0,0,0,132,2-propanol,tert-butanol,CC(C)O,CC(C)(C)O
+124,ethanol__hexane,39,0,39,0,17,0,23,118,ethanol,hexane,CCO,CCCCCC
+133,"1-propanol__2,2,4-trimethylpentane",108,0,0,0,0,0,0,108,1-propanol,"2,2,4-trimethylpentane",CCCO,CC(C)CC(C)(C)C
+134,pentane__heptane,107,0,0,0,0,0,0,107,pentane,heptane,CCCCC,CCCCCCC
+142,2-methoxyethanol__tert-butyl ethyl ether,105,0,0,0,0,0,0,105,2-methoxyethanol,tert-butyl ethyl ether,COCCO,CCOC(C)(C)C
+144,methanol__2-propanol,0,0,0,105,0,0,0,105,methanol,2-propanol,CO,CC(C)O
+145,methanol__2-methyl-1-propanol,0,0,0,105,0,0,0,105,methanol,2-methyl-1-propanol,CO,CC(C)CO
+146,methanol__1-butanol,0,0,0,105,0,0,0,105,methanol,1-butanol,CO,CCCCO
+147,methanol__1-propanol,0,0,0,105,0,0,0,105,methanol,1-propanol,CO,CCCO
+150,1-propanol__cyclopentane,63,0,39,0,0,0,0,102,1-propanol,cyclopentane,CCCO,C1CCCC1
+152,pentane__hexane,100,0,0,0,0,0,0,100,pentane,hexane,CCCCC,CCCCCC
+155,ethanol__3-methyl-1-butanol,98,0,0,0,0,0,0,98,ethanol,3-methyl-1-butanol,CCO,CC(C)CCO
+156,ethanol__2-methyl-2-butanol,98,0,0,0,0,0,0,98,ethanol,2-methyl-2-butanol,CCO,CCC(C)(C)O
+163,2-methoxyethanol__1-hexanol,48,0,48,0,0,0,0,96,2-methoxyethanol,1-hexanol,COCCO,CCCCCCO
+165,tetrahydrofuran__n-hexyl alcohol,48,0,48,0,0,0,0,96,tetrahydrofuran,n-hexyl alcohol,C1CCOC1,CCCCCCO
+172,methanol__2-methyl-2-propanol,0,0,0,95,0,0,0,95,methanol,2-methyl-2-propanol,CO,CC(C)(C)O
+173,1-butanol__water,75,8,11,0,0,0,0,94,1-butanol,water,CCCCO,O
+174,1-butanol__2-methyltetrahydrofuran,27,0,34,0,33,0,0,94,1-butanol,2-methyltetrahydrofuran,CCCCO,CC1CCCO1
+176,1-butanol__heptane,55,0,0,0,38,0,0,93,1-butanol,heptane,CCCCO,CCCCCCC
+179,oxacyclopentane__water,90,0,0,0,0,0,0,90,oxacyclopentane,water,C1CCOC1,O
+181,2-(2-methylpropoxy)ethanol__water,45,0,45,0,0,0,0,90,2-(2-methylpropoxy)ethanol,water,CC(C)COCCO,O
+182,1-propanol__cyclohexane,50,0,39,0,0,0,0,89,1-propanol,cyclohexane,CCCO,C1CCCCC1
+183,1-butanol__cyclopentane,39,0,39,0,11,0,0,89,1-butanol,cyclopentane,CCCCO,C1CCCC1
+184,ethyl alcohol__n-butyl alcohol,88,0,0,0,0,0,0,88,ethyl alcohol,n-butyl alcohol,CCO,CCCCO
+188,ethyl alcohol__pentan-1-ol,88,0,0,0,0,0,0,88,ethyl alcohol,pentan-1-ol,CCO,CCCCCO
+189,ethyl alcohol__propan-1-ol,88,0,0,0,0,0,0,88,ethyl alcohol,propan-1-ol,CCO,CCCO
+191,"2-methoxyethanol__ethanol, 2-ethoxy-",44,0,44,0,0,0,0,88,2-methoxyethanol,"ethanol, 2-ethoxy-",COCCO,CCOCCO
+193,"2-propanol__1,3-dioxolane",74,0,11,0,0,0,0,85,2-propanol,"1,3-dioxolane",CC(C)O,C1COCO1
+194,"2-propanol__pentane, 2,2,4-trimethyl-",84,0,0,0,0,0,0,84,2-propanol,"pentane, 2,2,4-trimethyl-",CC(C)O,CC(C)CC(C)(C)C
+195,"tetrahydropyran__pentane, 2,2,4-trimethyl-",84,0,0,0,0,0,0,84,tetrahydropyran,"pentane, 2,2,4-trimethyl-",C1CCOCC1,CC(C)CC(C)(C)C
+196,"1-hexanol__2,2,4-trimethylpentane",84,0,0,0,0,0,0,84,1-hexanol,"2,2,4-trimethylpentane",CCCCCCO,CC(C)CC(C)(C)C
+198,2-propanol__tetrahydropyran,84,0,0,0,0,0,0,84,2-propanol,tetrahydropyran,CC(C)O,C1CCOCC1
+203,1-butanol__methylcyclohexane,33,0,11,0,38,0,0,82,1-butanol,methylcyclohexane,CCCCO,CC1CCCCC1
+204,1-butanol__2-methyl-1-propanol,81,0,0,0,0,0,0,81,1-butanol,2-methyl-1-propanol,CCCCO,CC(C)CO
+206,2-methyl-1-propanol__water,79,0,0,0,0,0,0,79,2-methyl-1-propanol,water,CC(C)CO,O
+207,"1-pentanol__2,2,4-trimethylpentane",79,0,0,0,0,0,0,79,1-pentanol,"2,2,4-trimethylpentane",CCCCCO,CC(C)CC(C)(C)C
+208,2-propanol__cyclopentane,39,0,39,0,0,0,0,78,2-propanol,cyclopentane,CC(C)O,C1CCCC1
+209,ethanol__cyclopentane,39,0,39,0,0,0,0,78,ethanol,cyclopentane,CCO,C1CCCC1
+216,2-methyl-2-propanol__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,2-methyl-2-propanol,tert-butyl ethyl ether,CC(C)(C)O,CCOC(C)(C)C
+217,"2,2,4-trimethylpentane__tert-butyl ethyl ether",39,0,39,0,0,0,0,78,"2,2,4-trimethylpentane",tert-butyl ethyl ether,CC(C)CC(C)(C)C,CCOC(C)(C)C
+218,cyclopentane__2-pentanol,39,0,39,0,0,0,0,78,cyclopentane,2-pentanol,C1CCCC1,CCCC(C)O
+219,2-methyl-2-butanol__tetrahydrofuran,39,0,0,0,0,0,39,78,2-methyl-2-butanol,tetrahydrofuran,CCC(C)(C)O,C1CCOC1
+220,ethanol__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,ethanol,tert-butyl ethyl ether,CCO,CCOC(C)(C)C
+227,"n-heptane__2,2,4-trimethylpentane",77,0,0,0,0,0,0,77,n-heptane,"2,2,4-trimethylpentane",CCCCCCC,CC(C)CC(C)(C)C
+230,ethanol__2-propanol,0,0,0,0,76,0,0,76,ethanol,2-propanol,CCO,CC(C)O
+232,ethanol__1-propanol,0,0,0,0,74,0,0,74,ethanol,1-propanol,CCO,CCCO
+233,1-butanol__2-methyl-2-propanol,72,0,0,0,0,0,0,72,1-butanol,2-methyl-2-propanol,CCCCO,CC(C)(C)O
+235,tert-butanol__heptane,70,0,0,0,0,0,0,70,tert-butanol,heptane,CC(C)(C)O,CCCCCCC
+236,1-butanol__tetrahydropyran,0,0,35,0,33,0,0,68,1-butanol,tetrahydropyran,CCCCO,C1CCOCC1
+249,methanol__cyclohexane,64,0,0,0,0,0,0,64,methanol,cyclohexane,CO,C1CCCCC1
+256,ethanol__2-methyl-2-propanol,63,0,0,0,0,0,0,63,ethanol,2-methyl-2-propanol,CCO,CC(C)(C)O
+258,"2,2,4-trimethylpentane__1,3-dioxolane",63,0,0,0,0,0,0,63,"2,2,4-trimethylpentane","1,3-dioxolane",CC(C)CC(C)(C)C,C1COCO1
+260,"2-methyl-2-propanol__2,2,4-trimethylpentane",63,0,0,0,0,0,0,63,2-methyl-2-propanol,"2,2,4-trimethylpentane",CC(C)(C)O,CC(C)CC(C)(C)C
+268,cyclohexane__tetrahydropyran,0,0,13,0,32,0,14,59,cyclohexane,tetrahydropyran,C1CCCCC1,C1CCOCC1
+271,"ethanol, 2-ethoxy-__cyclohexane",0,0,0,0,58,0,0,58,"ethanol, 2-ethoxy-",cyclohexane,CCOCCO,C1CCCCC1
+274,n-propanol__water,56,0,0,0,0,0,0,56,n-propanol,water,CCCO,O
+275,"1-hexanol__1,4-dioxane",56,0,0,0,0,0,0,56,1-hexanol,"1,4-dioxane",CCCCCCO,C1COCCO1
+278,2-propanol__1-propanol,55,0,0,0,0,0,0,55,2-propanol,1-propanol,CC(C)O,CCCO
+284,1-propanol__isopropyl ether,32,0,21,0,0,0,0,53,1-propanol,isopropyl ether,CCCO,CC(C)OC(C)C
+297,"cyclohexane__1,4-dioxane",0,0,33,0,19,0,0,52,cyclohexane,"1,4-dioxane",C1CCCCC1,C1COCCO1
+298,"hexane__ethanol, 2-ethoxy-",0,0,0,0,51,0,0,51,hexane,"ethanol, 2-ethoxy-",CCCCCC,CCOCCO
+299,1-pentanol__cyclohexane,0,0,0,0,51,0,0,51,1-pentanol,cyclohexane,CCCCCO,C1CCCCC1
+306,"2,2,4-trimethylpentane__butane, 2-methoxy-2-methyl-",48,0,0,0,0,0,0,48,"2,2,4-trimethylpentane","butane, 2-methoxy-2-methyl-",CC(C)CC(C)(C)C,CCC(C)(C)OC
+314,1-hexanol__heptane,45,0,0,0,0,0,0,45,1-hexanol,heptane,CCCCCCO,CCCCCCC
+315,isopropanol__isobutyl alcohol,45,0,0,0,0,0,0,45,isopropanol,isobutyl alcohol,CC(C)O,CC(C)CO
+321,n-propyl alcohol__isobutyl alcohol,44,0,0,0,0,0,0,44,n-propyl alcohol,isobutyl alcohol,CCCO,CC(C)CO
+323,1-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,1-propanol,methylcyclohexane,CCCO,CC1CCCCC1
+327,2-methyl-1-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,2-methyl-1-propanol,methylcyclohexane,CC(C)CO,CC1CCCCC1
+328,methylcyclohexane__3-methyl-1-butanol,33,0,11,0,0,0,0,44,methylcyclohexane,3-methyl-1-butanol,CC1CCCCC1,CC(C)CCO
+330,2-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,2-propanol,methylcyclohexane,CC(C)O,CC1CCCCC1
+334,ethanol__isopropyl ether,24,0,0,0,19,0,0,43,ethanol,isopropyl ether,CCO,CC(C)OC(C)C
+342,ethylene glycol methyl ether__water,21,0,21,0,0,0,0,42,ethylene glycol methyl ether,water,COCCO,O
+343,1-propanol__tert-amyl methyl ether,21,0,21,0,0,0,0,42,1-propanol,tert-amyl methyl ether,CCCO,CCC(C)(C)OC
+345,"isopropyl ether__2,2,4-trimethylpentane",13,0,10,0,19,0,0,42,isopropyl ether,"2,2,4-trimethylpentane",CC(C)OC(C)C,CC(C)CC(C)(C)C
+347,n-hexane__tetrahydropyran,0,0,14,0,14,0,14,42,n-hexane,tetrahydropyran,CCCCCC,C1CCOCC1
+349,tetrahydropyran__heptane,0,0,14,0,14,0,14,42,tetrahydropyran,heptane,C1CCOCC1,CCCCCCC
+351,n-heptane__2-pentanol,0,0,0,0,42,0,0,42,n-heptane,2-pentanol,CCCCCCC,CCCC(C)O
+352,pentan-1-ol__isooctane,0,0,0,0,42,0,0,42,pentan-1-ol,isooctane,CCCCCO,CCCCCC(C)C
+354,pentan-1-ol__heptane,0,0,0,0,42,0,0,42,pentan-1-ol,heptane,CCCCCO,CCCCCCC
+355,"2,2,4-trimethylpentane__2-pentanol",0,0,0,0,42,0,0,42,"2,2,4-trimethylpentane",2-pentanol,CC(C)CC(C)(C)C,CCCC(C)O
+358,cyclohexane__2-pentanol,39,0,0,0,0,0,0,39,cyclohexane,2-pentanol,C1CCCCC1,CCCC(C)O
+359,cyclohexane__heptane,39,0,0,0,0,0,0,39,cyclohexane,heptane,C1CCCCC1,CCCCCCC
+361,1-propanol__2-methyl-1-butanol,19,0,19,0,0,0,0,38,1-propanol,2-methyl-1-butanol,CCCO,CCC(C)CO
+362,1-propanol__3-methyl-1-butanol,19,0,19,0,0,0,0,38,1-propanol,3-methyl-1-butanol,CCCO,CC(C)CCO
+363,methanol__2-methyl-1-butanol,19,0,19,0,0,0,0,38,methanol,2-methyl-1-butanol,CO,CCC(C)CO
+364,"hexane__ether, methyl tert-pentyl",19,0,0,0,0,0,19,38,hexane,"ether, methyl tert-pentyl",CCCCCC,CCC(C)(C)OC
+372,1-pentanol__cyclopentane,26,0,0,0,10,0,0,36,1-pentanol,cyclopentane,CCCCCO,C1CCCC1
+374,2-isopropoxyethanol__water,18,0,18,0,0,0,0,36,2-isopropoxyethanol,water,CC(C)OCCO,O
+386,"1,4-dioxane__cyclopentane",0,0,33,0,0,0,0,33,"1,4-dioxane",cyclopentane,C1COCCO1,C1CCCC1
+388,2-methyl-1-propanol__hexane,16,0,16,0,0,0,0,32,2-methyl-1-propanol,hexane,CC(C)CO,CCCCCC
+393,propan-1-ol__water,30,0,0,0,0,0,0,30,propan-1-ol,water,CCCO,O
+411,"ethanol, 2-ethoxy-__water",12,0,16,0,0,0,0,28,"ethanol, 2-ethoxy-",water,CCOCCO,O
+412,"1,4-dioxane__water",10,0,18,0,0,0,0,28,"1,4-dioxane",water,C1COCCO1,O
+417,"cyclopentane__1,3-dioxolane",0,0,27,0,0,0,0,27,cyclopentane,"1,3-dioxolane",C1CCCC1,C1COCO1
+418,"cyclohexane__1,3-dioxolane",0,0,27,0,0,0,0,27,cyclohexane,"1,3-dioxolane",C1CCCCC1,C1COCO1
+424,n-propyl alcohol__water,25,0,0,0,0,0,0,25,n-propyl alcohol,water,CCCO,O
+430,2-ethoxyethanol__water,24,0,0,0,0,0,0,24,2-ethoxyethanol,water,CCOCCO,O
+433,isobutanol__water,12,0,12,0,0,0,0,24,isobutanol,water,CC(C)CO,O
+435,"ethane, 1,1'-oxybis-__1,3-dioxolane",11,0,12,0,0,0,0,23,"ethane, 1,1'-oxybis-","1,3-dioxolane",CCOCC,C1COCO1
+436,neohexane__tetrahydrofuran,0,0,0,0,23,0,0,23,neohexane,tetrahydrofuran,CCC(C)(C)C,C1CCOC1
+437,diisopropyl__tetrahydrofuran,0,0,0,0,23,0,0,23,diisopropyl,tetrahydrofuran,CC(C)C(C)C,C1CCOC1
+445,heptane__cyclooctane,22,0,0,0,0,0,0,22,heptane,cyclooctane,CCCCCCC,C1CCCCCCC1
+452,1-propanol__1-pentanol,22,0,0,0,0,0,0,22,1-propanol,1-pentanol,CCCO,CCCCCO
+457,"ethane, 1,1'-oxybis-__pentan-1-ol",11,0,11,0,0,0,0,22,"ethane, 1,1'-oxybis-",pentan-1-ol,CCOCC,CCCCCO
+458,"2-methoxyethanol__1,3-dioxolane",11,0,11,0,0,0,0,22,2-methoxyethanol,"1,3-dioxolane",COCCO,C1COCO1
+459,"pentan-1-ol__1,3-dioxolane",11,0,11,0,0,0,0,22,pentan-1-ol,"1,3-dioxolane",CCCCCO,C1COCO1
+460,"ethanol, 2-ethoxy-__1,3-dioxolane",11,0,11,0,0,0,0,22,"ethanol, 2-ethoxy-","1,3-dioxolane",CCOCCO,C1COCO1
+467,"2,3-dimethylbutane__ether, dipropyl",0,0,0,0,20,0,0,20,"2,3-dimethylbutane","ether, dipropyl",CC(C)C(C)C,CCCOCCC
+470,tetramethylene oxide__dipropyl ether,0,0,0,0,20,0,0,20,tetramethylene oxide,dipropyl ether,C1CCOC1,CCCOCCC
+473,2-methyl-1-propanol__2-methyl-1-butanol,19,0,0,0,0,0,0,19,2-methyl-1-propanol,2-methyl-1-butanol,CC(C)CO,CCC(C)CO
+474,2-methyl-1-propanol__3-methyl-1-butanol,19,0,0,0,0,0,0,19,2-methyl-1-propanol,3-methyl-1-butanol,CC(C)CO,CC(C)CCO
+475,1-propanol__tert-butyl ethyl ether,19,0,0,0,0,0,0,19,1-propanol,tert-butyl ethyl ether,CCCO,CCOC(C)(C)C
+476,1-pentanol__2-methyl-1-propanol,19,0,0,0,0,0,0,19,1-pentanol,2-methyl-1-propanol,CCCCCO,CC(C)CO
+478,"butane, 2,2-dimethyl-__ether, dipropyl",0,0,0,0,19,0,0,19,"butane, 2,2-dimethyl-","ether, dipropyl",CCC(C)(C)C,CCCOCCC
+481,methanol__methoxymethane,0,0,0,0,19,0,0,19,methanol,methoxymethane,CO,COC
+484,1-propanol__methoxymethane,0,0,0,0,19,0,0,19,1-propanol,methoxymethane,CCCO,COC
+486,ethanol__methoxymethane,0,0,0,0,19,0,0,19,ethanol,methoxymethane,CCO,COC
+487,1-butanol__methoxymethane,0,0,0,0,19,0,0,19,1-butanol,methoxymethane,CCCCO,COC
+491,ethanol__tetrahydropyran,0,0,0,0,19,0,0,19,ethanol,tetrahydropyran,CCO,C1CCOCC1
+497,hexane__cyclohexane,0,0,0,0,18,0,0,18,hexane,cyclohexane,CCCCCC,C1CCCCC1
+499,1-pentanol__hexane,0,0,0,0,18,0,0,18,1-pentanol,hexane,CCCCCO,CCCCCC
+505,2-methyl-1-propanol__1-methyl-1-(1-methylethoxy)ethane,0,0,0,0,17,0,0,17,2-methyl-1-propanol,1-methyl-1-(1-methylethoxy)ethane,CC(C)CO,CC(C)OC(C)C
+507,methanol__dioxane,16,0,0,0,0,0,0,16,methanol,dioxane,CO,C1COCCO1
+508,tert-pentyl alcohol__water,0,16,0,0,0,0,0,16,tert-pentyl alcohol,water,CCC(C)(C)O,O
+509,2-methoxyethanol__water,0,0,16,0,0,0,0,16,2-methoxyethanol,water,COCCO,O
+510,1-propanol__heptane,0,0,0,0,16,0,0,16,1-propanol,heptane,CCCO,CCCCCCC
+511,methane__pentane,15,0,0,0,0,0,0,15,methane,pentane,C,CCCCC
+512,"1-butanol, 3-methyl-__water",0,15,0,0,0,0,0,15,"1-butanol, 3-methyl-",water,CC(C)CCO,O
+513,2-methyl-1-butanol__water,0,15,0,0,0,0,0,15,2-methyl-1-butanol,water,CCC(C)CO,O
+521,ethanol__oxane,13,0,0,0,0,0,0,13,ethanol,oxane,CCO,C1CCOCC1
+525,pentan-2-ol__water,0,13,0,0,0,0,0,13,pentan-2-ol,water,CCCC(C)O,O
+527,1-butanol__1-methyl-1-(1-methylethoxy)ethane,0,0,0,0,13,0,0,13,1-butanol,1-methyl-1-(1-methylethoxy)ethane,CCCCO,CC(C)OC(C)C
+529,"1,3-dioxolane__water",12,0,0,0,0,0,0,12,"1,3-dioxolane",water,C1COCO1,O
+530,2-propanol__methane,12,0,0,0,0,0,0,12,2-propanol,methane,CC(C)O,C
+531,methanol__tetrahydrofuran,12,0,0,0,0,0,0,12,methanol,tetrahydrofuran,CO,C1CCOC1
+532,1-methyl-1-(1-methylethoxy)ethane__heptane,0,0,0,0,12,0,0,12,1-methyl-1-(1-methylethoxy)ethane,heptane,CC(C)OC(C)C,CCCCCCC
+545,1-hexanol__cyclopentane,0,0,0,0,11,0,0,11,1-hexanol,cyclopentane,CCCCCCO,C1CCCC1
+550,2-propanol__ethane,10,0,0,0,0,0,0,10,2-propanol,ethane,CC(C)O,CC
+553,3-methyl-2-butanol__water,0,10,0,0,0,0,0,10,3-methyl-2-butanol,water,CC(C)C(C)O,O
+554,isopropyl ether__hexane,0,0,10,0,0,0,0,10,isopropyl ether,hexane,CC(C)OC(C)C,CCCCCC
+555,isopropyl ether__heptane,0,0,10,0,0,0,0,10,isopropyl ether,heptane,CC(C)OC(C)C,CCCCCCC
+558,pentan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,pentan-1-ol,tert-pentyl alcohol,CCCCCO,CCC(C)(C)O
+562,ethanol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,ethanol,tert-pentyl alcohol,CCO,CCC(C)(C)O
+563,butan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,butan-1-ol,tert-pentyl alcohol,CCCCO,CCC(C)(C)O
+569,propan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,propan-1-ol,tert-pentyl alcohol,CCCO,CCC(C)(C)O
+572,methanol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,methanol,tert-pentyl alcohol,CO,CCC(C)(C)O
+573,ethane__pentane,9,0,0,0,0,0,0,9,ethane,pentane,CC,CCCCC
+574,(RS)-2-butanol__water,9,0,0,0,0,0,0,9,(RS)-2-butanol,water,CCC(C)O,O
+579,isopropyl ether__cyclohexane,0,0,9,0,0,0,0,9,isopropyl ether,cyclohexane,CC(C)OC(C)C,C1CCCCC1
+584,1-pentanol__tetrahydropyran,0,0,0,0,9,0,0,9,1-pentanol,tetrahydropyran,CCCCCO,C1CCOCC1
+587,"1,4-dioxane__tetrahydropyran",0,0,0,0,9,0,0,9,"1,4-dioxane",tetrahydropyran,C1COCCO1,C1CCOCC1
+594,isopropyl ether__isooctane,8,0,0,0,0,0,0,8,isopropyl ether,isooctane,CC(C)OC(C)C,CCCCCC(C)C
+598,methane__butane,6,0,0,0,0,0,0,6,methane,butane,C,CCCC
+601,methanol__2-methoxyethanol,5,0,0,0,0,0,0,5,methanol,2-methoxyethanol,CO,COCCO
+610,methane__ethane,4,0,0,0,0,0,0,4,methane,ethane,C,CC
+624,tert-amyl methyl ether__water,0,4,0,0,0,0,0,4,tert-amyl methyl ether,water,CCC(C)(C)OC,O
+626,tert-butyl ethyl ether__water,0,4,0,0,0,0,0,4,tert-butyl ethyl ether,water,CCOC(C)(C)C,O
+630,methanol__ethane,3,0,0,0,0,0,0,3,methanol,ethane,CO,CC
+670,methylcyclopentane__methyl cellosolve,0,1,0,0,0,0,0,1,methylcyclopentane,methyl cellosolve,CC1CCCC1,COCCO
+672,methyl cellosolve__cyclohexane,0,1,0,0,0,0,0,1,methyl cellosolve,cyclohexane,COCCO,C1CCCCC1
+673,methyl cellosolve__cyclooctane,0,1,0,0,0,0,0,1,methyl cellosolve,cyclooctane,COCCO,C1CCCCCCC1
+675,methylcyclohexane__methyl cellosolve,0,1,0,0,0,0,0,1,methylcyclohexane,methyl cellosolve,CC1CCCCC1,COCCO
+691,methyl cellosolve__n-heptane,0,1,0,0,0,0,0,1,methyl cellosolve,n-heptane,COCCO,CCCCCCC
+692,methyl cellosolve__n-hexane,0,1,0,0,0,0,0,1,methyl cellosolve,n-hexane,COCCO,CCCCCC

--- a/Initial Molecule Choices/mix_counts_interesting.csv
+++ b/Initial Molecule Choices/mix_counts_interesting.csv
@@ -1,181 +1,678 @@
-,Unnamed: 0,Mixture,Mixture Count dens binary,Mixture Count actcoeff binary,Mixture Count sos binary,Mixture Count dielec binary,Mixture Count eme binary,Mixture Count emcp binary,Mixture Count emv binary,Mixture Count all,x1,x2,SMILES1,SMILES2
-2,2,2-propanol__water,1012,0,0,0,45,0,0,1057,2-propanol,water,CC(C)O,O
-9,9,ethanol__water,712,0,20,0,83,0,0,815,ethanol,water,CCO,O
-5,5,ethanol__methylcyclohexane,753,0,11,0,0,0,0,764,ethanol,methylcyclohexane,CCO,CC1CCCCC1
-10,10,ethanol__heptane,708,0,39,0,0,0,0,747,ethanol,heptane,CCO,CCCCCCC
-11,11,2-methyl-2-propanol__water,636,0,6,0,0,0,0,642,2-methyl-2-propanol,water,CC(C)(C)O,O
-12,12,1-butanol__cyclohexane,501,0,51,0,38,0,0,590,1-butanol,cyclohexane,CCCCO,C1CCCCC1
-89,89,tert-pentyl alcohol__heptane,102,0,450,0,0,0,0,552,tert-pentyl alcohol,heptane,CCC(C)(C)O,CCCCCCC
-17,17,1-propoxy-2-propanol__water,318,0,145,0,0,0,0,463,1-propoxy-2-propanol,water,CCCOCC(C)O,O
-33,33,methanol__water,212,0,12,0,140,0,0,364,methanol,water,CO,O
-14,14,tert-butanol__water,360,0,0,0,0,0,0,360,tert-butanol,water,CC(C)(C)O,O
-16,16,n-butyl alcohol__2-methylheptane,324,0,0,0,0,0,0,324,n-butyl alcohol,2-methylheptane,CCCCO,CCCCCC(C)C
-184,184,ethanol__methanol,63,0,0,105,76,0,0,244,ethanol,methanol,CCO,CO
-31,31,tetrahydrofuran__water,220,0,20,0,0,0,0,240,tetrahydrofuran,water,C1CCOC1,O
-32,32,neopentyl alcohol__water,213,0,0,0,0,0,0,213,neopentyl alcohol,water,CC(C)(C)CO,O
-96,96,"1-butanol__2,2,4-trimethylpentane",93,0,80,0,38,0,0,211,1-butanol,"2,2,4-trimethylpentane",CCCCO,CC(C)CC(C)(C)C
-34,34,"2-methyl-1,3-propanediol__water",209,0,0,0,0,0,0,209,"2-methyl-1,3-propanediol",water,CC(CO)CO,O
-51,51,1-propanol__water,172,0,27,0,0,0,0,199,1-propanol,water,CCCO,O
-186,186,1-butanol__hexane,60,0,60,0,23,0,31,174,1-butanol,hexane,CCCCO,CCCCCC
-59,59,"ethanol__2,2,4-trimethylpentane",150,0,0,0,19,0,0,169,ethanol,"2,2,4-trimethylpentane",CCO,CC(C)CC(C)(C)C
-127,127,2-propanol__cyclohexane,78,0,78,0,9,0,0,165,2-propanol,cyclohexane,CC(C)O,C1CCCCC1
-56,56,"2,2-dimethyl-1,3-propanediol__water",156,0,0,0,0,0,0,156,"2,2-dimethyl-1,3-propanediol",water,CC(C)(CO)CO,O
-80,80,ethanol__cyclohexane,111,0,39,0,0,0,0,150,ethanol,cyclohexane,CCO,C1CCCCC1
-143,143,ethanol__isooctane,72,0,72,0,0,0,0,144,ethanol,isooctane,CCO,CCCCCC(C)C
-69,69,"3-methylpentane-1,5-diol__water",138,0,0,0,0,0,0,138,"3-methylpentane-1,5-diol",water,CC(CCO)CCO,O
-77,77,ethanol__2-methyl-1-butanol,116,0,18,0,0,0,0,134,ethanol,2-methyl-1-butanol,CCO,CCC(C)CO
-157,157,1-propanol__tert-butanol,66,0,66,0,0,0,0,132,1-propanol,tert-butanol,CCCO,CC(C)(C)O
-160,160,2-propanol__tert-butanol,66,0,66,0,0,0,0,132,2-propanol,tert-butanol,CC(C)O,CC(C)(C)O
-266,266,ethanol__hexane,39,0,39,0,17,0,23,118,ethanol,hexane,CCO,CCCCCC
-81,81,"1-propanol__2,2,4-trimethylpentane",108,0,0,0,0,0,0,108,1-propanol,"2,2,4-trimethylpentane",CCCO,CC(C)CC(C)(C)C
-87,87,2-methoxyethanol__tert-butyl ethyl ether,105,0,0,0,0,0,0,105,2-methoxyethanol,tert-butyl ethyl ether,COCCO,CCOC(C)(C)C
-592,592,methanol__2-propanol,0,0,0,105,0,0,0,105,methanol,2-propanol,CO,CC(C)O
-593,593,methanol__2-methyl-1-propanol,0,0,0,105,0,0,0,105,methanol,2-methyl-1-propanol,CO,CC(C)CO
-594,594,methanol__1-butanol,0,0,0,105,0,0,0,105,methanol,1-butanol,CO,CCCCO
-595,595,methanol__1-propanol,0,0,0,105,0,0,0,105,methanol,1-propanol,CO,CCCO
-177,177,1-propanol__cyclopentane,63,0,39,0,0,0,0,102,1-propanol,cyclopentane,CCCO,C1CCCC1
-93,93,ethanol__3-methyl-1-butanol,98,0,0,0,0,0,0,98,ethanol,3-methyl-1-butanol,CCO,CC(C)CCO
-94,94,ethanol__2-methyl-2-butanol,98,0,0,0,0,0,0,98,ethanol,2-methyl-2-butanol,CCO,CCC(C)(C)O
-223,223,2-methoxyethanol__1-hexanol,48,0,48,0,0,0,0,96,2-methoxyethanol,1-hexanol,COCCO,CCCCCCO
-225,225,tetrahydrofuran__n-hexyl alcohol,48,0,48,0,0,0,0,96,tetrahydrofuran,n-hexyl alcohol,C1CCOC1,CCCCCCO
-596,596,methanol__2-methyl-2-propanol,0,0,0,95,0,0,0,95,methanol,2-methyl-2-propanol,CO,CC(C)(C)O
-138,138,1-butanol__water,75,8,11,0,0,0,0,94,1-butanol,water,CCCCO,O
-320,320,1-butanol__2-methyltetrahydrofuran,27,0,34,0,33,0,0,94,1-butanol,2-methyltetrahydrofuran,CCCCO,CC1CCCO1
-203,203,1-butanol__heptane,55,0,0,0,38,0,0,93,1-butanol,heptane,CCCCO,CCCCCCC
-101,101,oxacyclopentane__water,90,0,0,0,0,0,0,90,oxacyclopentane,water,C1CCOC1,O
-245,245,2-(2-methylpropoxy)ethanol__water,45,0,45,0,0,0,0,90,2-(2-methylpropoxy)ethanol,water,CC(C)COCCO,O
-213,213,1-propanol__cyclohexane,50,0,39,0,0,0,0,89,1-propanol,cyclohexane,CCCO,C1CCCCC1
-269,269,1-butanol__cyclopentane,39,0,39,0,11,0,0,89,1-butanol,cyclopentane,CCCCO,C1CCCC1
-102,102,ethyl alcohol__n-butyl alcohol,88,0,0,0,0,0,0,88,ethyl alcohol,n-butyl alcohol,CCO,CCCCO
-107,107,ethyl alcohol__pentan-1-ol,88,0,0,0,0,0,0,88,ethyl alcohol,pentan-1-ol,CCO,CCCCCO
-109,109,ethyl alcohol__propan-1-ol,88,0,0,0,0,0,0,88,ethyl alcohol,propan-1-ol,CCO,CCCO
-246,246,"2-methoxyethanol__ethanol, 2-ethoxy-",44,0,44,0,0,0,0,88,2-methoxyethanol,"ethanol, 2-ethoxy-",COCCO,CCOCCO
-140,140,"2-propanol__1,3-dioxolane",74,0,11,0,0,0,0,85,2-propanol,"1,3-dioxolane",CC(C)O,C1COCO1
-114,114,"2-propanol__pentane, 2,2,4-trimethyl-",84,0,0,0,0,0,0,84,2-propanol,"pentane, 2,2,4-trimethyl-",CC(C)O,CC(C)CC(C)(C)C
-115,115,"tetrahydropyran__pentane, 2,2,4-trimethyl-",84,0,0,0,0,0,0,84,tetrahydropyran,"pentane, 2,2,4-trimethyl-",C1CCOCC1,CC(C)CC(C)(C)C
-116,116,"1-hexanol__2,2,4-trimethylpentane",84,0,0,0,0,0,0,84,1-hexanol,"2,2,4-trimethylpentane",CCCCCCO,CC(C)CC(C)(C)C
-119,119,2-propanol__tetrahydropyran,84,0,0,0,0,0,0,84,2-propanol,tetrahydropyran,CC(C)O,C1CCOCC1
-305,305,1-butanol__methylcyclohexane,33,0,11,0,38,0,0,82,1-butanol,methylcyclohexane,CCCCO,CC1CCCCC1
-122,122,1-butanol__2-methyl-1-propanol,81,0,0,0,0,0,0,81,1-butanol,2-methyl-1-propanol,CCCCO,CC(C)CO
-125,125,2-methyl-1-propanol__water,79,0,0,0,0,0,0,79,2-methyl-1-propanol,water,CC(C)CO,O
-126,126,"1-pentanol__2,2,4-trimethylpentane",79,0,0,0,0,0,0,79,1-pentanol,"2,2,4-trimethylpentane",CCCCCO,CC(C)CC(C)(C)C
-263,263,2-propanol__cyclopentane,39,0,39,0,0,0,0,78,2-propanol,cyclopentane,CC(C)O,C1CCCC1
-264,264,ethanol__cyclopentane,39,0,39,0,0,0,0,78,ethanol,cyclopentane,CCO,C1CCCC1
-274,274,2-methyl-2-propanol__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,2-methyl-2-propanol,tert-butyl ethyl ether,CC(C)(C)O,CCOC(C)(C)C
-275,275,"2,2,4-trimethylpentane__tert-butyl ethyl ether",39,0,39,0,0,0,0,78,"2,2,4-trimethylpentane",tert-butyl ethyl ether,CC(C)CC(C)(C)C,CCOC(C)(C)C
-276,276,cyclopentane__2-pentanol,39,0,39,0,0,0,0,78,cyclopentane,2-pentanol,C1CCCC1,CCCC(C)O
-277,277,2-methyl-2-butanol__tetrahydrofuran,39,0,0,0,0,0,39,78,2-methyl-2-butanol,tetrahydrofuran,CCC(C)(C)O,C1CCOC1
-279,279,ethanol__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,ethanol,tert-butyl ethyl ether,CCO,CCOC(C)(C)C
-600,600,ethanol__2-propanol,0,0,0,0,76,0,0,76,ethanol,2-propanol,CCO,CC(C)O
-601,601,ethanol__1-propanol,0,0,0,0,74,0,0,74,ethanol,1-propanol,CCO,CCCO
-144,144,1-butanol__2-methyl-2-propanol,72,0,0,0,0,0,0,72,1-butanol,2-methyl-2-propanol,CCCCO,CC(C)(C)O
-151,151,tert-butanol__heptane,70,0,0,0,0,0,0,70,tert-butanol,heptane,CC(C)(C)O,CCCCCCC
-566,566,1-butanol__tetrahydropyran,0,0,35,0,33,0,0,68,1-butanol,tetrahydropyran,CCCCO,C1CCOCC1
-174,174,methanol__cyclohexane,64,0,0,0,0,0,0,64,methanol,cyclohexane,CO,C1CCCCC1
-178,178,ethanol__2-methyl-2-propanol,63,0,0,0,0,0,0,63,ethanol,2-methyl-2-propanol,CCO,CC(C)(C)O
-181,181,"2,2,4-trimethylpentane__1,3-dioxolane",63,0,0,0,0,0,0,63,"2,2,4-trimethylpentane","1,3-dioxolane",CC(C)CC(C)(C)C,C1COCO1
-183,183,"2-methyl-2-propanol__2,2,4-trimethylpentane",63,0,0,0,0,0,0,63,2-methyl-2-propanol,"2,2,4-trimethylpentane",CC(C)(C)O,CC(C)CC(C)(C)C
-583,583,cyclohexane__tetrahydropyran,0,0,13,0,32,0,14,59,cyclohexane,tetrahydropyran,C1CCCCC1,C1CCOCC1
-604,604,"ethanol, 2-ethoxy-__cyclohexane",0,0,0,0,58,0,0,58,"ethanol, 2-ethoxy-",cyclohexane,CCOCCO,C1CCCCC1
-194,194,n-propanol__water,56,0,0,0,0,0,0,56,n-propanol,water,CCCO,O
-196,196,"1-hexanol__1,4-dioxane",56,0,0,0,0,0,0,56,1-hexanol,"1,4-dioxane",CCCCCCO,C1COCCO1
-202,202,2-propanol__1-propanol,55,0,0,0,0,0,0,55,2-propanol,1-propanol,CC(C)O,CCCO
-310,310,1-propanol__isopropyl ether,32,0,21,0,0,0,0,53,1-propanol,isopropyl ether,CCCO,CC(C)OC(C)C
-568,568,"cyclohexane__1,4-dioxane",0,0,33,0,19,0,0,52,cyclohexane,"1,4-dioxane",C1CCCCC1,C1COCCO1
-606,606,"hexane__ethanol, 2-ethoxy-",0,0,0,0,51,0,0,51,hexane,"ethanol, 2-ethoxy-",CCCCCC,CCOCCO
-607,607,1-pentanol__cyclohexane,0,0,0,0,51,0,0,51,1-pentanol,cyclohexane,CCCCCO,C1CCCCC1
-227,227,"2,2,4-trimethylpentane__butane, 2-methoxy-2-methyl-",48,0,0,0,0,0,0,48,"2,2,4-trimethylpentane","butane, 2-methoxy-2-methyl-",CC(C)CC(C)(C)C,CCC(C)(C)OC
-240,240,1-hexanol__heptane,45,0,0,0,0,0,0,45,1-hexanol,heptane,CCCCCCO,CCCCCCC
-242,242,isopropanol__isobutyl alcohol,45,0,0,0,0,0,0,45,isopropanol,isobutyl alcohol,CC(C)O,CC(C)CO
-248,248,n-propyl alcohol__isobutyl alcohol,44,0,0,0,0,0,0,44,n-propyl alcohol,isobutyl alcohol,CCCO,CC(C)CO
-291,291,1-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,1-propanol,methylcyclohexane,CCCO,CC1CCCCC1
-296,296,2-methyl-1-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,2-methyl-1-propanol,methylcyclohexane,CC(C)CO,CC1CCCCC1
-297,297,methylcyclohexane__3-methyl-1-butanol,33,0,11,0,0,0,0,44,methylcyclohexane,3-methyl-1-butanol,CC1CCCCC1,CC(C)CCO
-299,299,2-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,2-propanol,methylcyclohexane,CC(C)O,CC1CCCCC1
-346,346,ethanol__isopropyl ether,24,0,0,0,19,0,0,43,ethanol,isopropyl ether,CCO,CC(C)OC(C)C
-371,371,ethylene glycol methyl ether__water,21,0,21,0,0,0,0,42,ethylene glycol methyl ether,water,COCCO,O
-372,372,1-propanol__tert-amyl methyl ether,21,0,21,0,0,0,0,42,1-propanol,tert-amyl methyl ether,CCCO,CCC(C)(C)OC
-408,408,"isopropyl ether__2,2,4-trimethylpentane",13,0,10,0,19,0,0,42,isopropyl ether,"2,2,4-trimethylpentane",CC(C)OC(C)C,CC(C)CC(C)(C)C
-578,578,n-hexane__tetrahydropyran,0,0,14,0,14,0,14,42,n-hexane,tetrahydropyran,CCCCCC,C1CCOCC1
-580,580,tetrahydropyran__heptane,0,0,14,0,14,0,14,42,tetrahydropyran,heptane,C1CCOCC1,CCCCCCC
-608,608,n-heptane__2-pentanol,0,0,0,0,42,0,0,42,n-heptane,2-pentanol,CCCCCCC,CCCC(C)O
-609,609,pentan-1-ol__isooctane,0,0,0,0,42,0,0,42,pentan-1-ol,isooctane,CCCCCO,CCCCCC(C)C
-611,611,pentan-1-ol__heptane,0,0,0,0,42,0,0,42,pentan-1-ol,heptane,CCCCCO,CCCCCCC
-612,612,"2,2,4-trimethylpentane__2-pentanol",0,0,0,0,42,0,0,42,"2,2,4-trimethylpentane",2-pentanol,CC(C)CC(C)(C)C,CCCC(C)O
-270,270,cyclohexane__2-pentanol,39,0,0,0,0,0,0,39,cyclohexane,2-pentanol,C1CCCCC1,CCCC(C)O
-377,377,1-propanol__2-methyl-1-butanol,19,0,19,0,0,0,0,38,1-propanol,2-methyl-1-butanol,CCCO,CCC(C)CO
-378,378,1-propanol__3-methyl-1-butanol,19,0,19,0,0,0,0,38,1-propanol,3-methyl-1-butanol,CCCO,CC(C)CCO
-379,379,methanol__2-methyl-1-butanol,19,0,19,0,0,0,0,38,methanol,2-methyl-1-butanol,CO,CCC(C)CO
-383,383,"hexane__ether, methyl tert-pentyl",19,0,0,0,0,0,19,38,hexane,"ether, methyl tert-pentyl",CCCCCC,CCC(C)(C)OC
-335,335,1-pentanol__cyclopentane,26,0,0,0,10,0,0,36,1-pentanol,cyclopentane,CCCCCO,C1CCCC1
-387,387,2-isopropoxyethanol__water,18,0,18,0,0,0,0,36,2-isopropoxyethanol,water,CC(C)OCCO,O
-567,567,"1,4-dioxane__cyclopentane",0,0,33,0,0,0,0,33,"1,4-dioxane",cyclopentane,C1COCCO1,C1CCCC1
-389,389,2-methyl-1-propanol__hexane,16,0,16,0,0,0,0,32,2-methyl-1-propanol,hexane,CC(C)CO,CCCCCC
-317,317,propan-1-ol__water,30,0,0,0,0,0,0,30,propan-1-ol,water,CCCO,O
-418,418,"ethanol, 2-ethoxy-__water",12,0,16,0,0,0,0,28,"ethanol, 2-ethoxy-",water,CCOCCO,O
-440,440,"1,4-dioxane__water",10,0,18,0,0,0,0,28,"1,4-dioxane",water,C1COCCO1,O
-574,574,"cyclopentane__1,3-dioxolane",0,0,27,0,0,0,0,27,cyclopentane,"1,3-dioxolane",C1CCCC1,C1COCO1
-575,575,"cyclohexane__1,3-dioxolane",0,0,27,0,0,0,0,27,cyclohexane,"1,3-dioxolane",C1CCCCC1,C1COCO1
-339,339,n-propyl alcohol__water,25,0,0,0,0,0,0,25,n-propyl alcohol,water,CCCO,O
-345,345,2-ethoxyethanol__water,24,0,0,0,0,0,0,24,2-ethoxyethanol,water,CCOCCO,O
-413,413,isobutanol__water,12,0,12,0,0,0,0,24,isobutanol,water,CC(C)CO,O
-424,424,"ethane, 1,1'-oxybis-__1,3-dioxolane",11,0,12,0,0,0,0,23,"ethane, 1,1'-oxybis-","1,3-dioxolane",CCOCC,C1COCO1
-621,621,neohexane__tetrahydrofuran,0,0,0,0,23,0,0,23,neohexane,tetrahydrofuran,CCC(C)(C)C,C1CCOC1
-622,622,diisopropyl__tetrahydrofuran,0,0,0,0,23,0,0,23,diisopropyl,tetrahydrofuran,CC(C)C(C)C,C1CCOC1
-367,367,1-propanol__1-pentanol,22,0,0,0,0,0,0,22,1-propanol,1-pentanol,CCCO,CCCCCO
-425,425,"ethane, 1,1'-oxybis-__pentan-1-ol",11,0,11,0,0,0,0,22,"ethane, 1,1'-oxybis-",pentan-1-ol,CCOCC,CCCCCO
-426,426,"2-methoxyethanol__1,3-dioxolane",11,0,11,0,0,0,0,22,2-methoxyethanol,"1,3-dioxolane",COCCO,C1COCO1
-431,431,"pentan-1-ol__1,3-dioxolane",11,0,11,0,0,0,0,22,pentan-1-ol,"1,3-dioxolane",CCCCCO,C1COCO1
-432,432,"ethanol, 2-ethoxy-__1,3-dioxolane",11,0,11,0,0,0,0,22,"ethanol, 2-ethoxy-","1,3-dioxolane",CCOCCO,C1COCO1
-624,624,"2,3-dimethylbutane__ether, dipropyl",0,0,0,0,20,0,0,20,"2,3-dimethylbutane","ether, dipropyl",CC(C)C(C)C,CCCOCCC
-627,627,tetramethylene oxide__dipropyl ether,0,0,0,0,20,0,0,20,tetramethylene oxide,dipropyl ether,C1CCOC1,CCCOCCC
-376,376,2-methyl-1-propanol__2-methyl-1-butanol,19,0,0,0,0,0,0,19,2-methyl-1-propanol,2-methyl-1-butanol,CC(C)CO,CCC(C)CO
-380,380,2-methyl-1-propanol__3-methyl-1-butanol,19,0,0,0,0,0,0,19,2-methyl-1-propanol,3-methyl-1-butanol,CC(C)CO,CC(C)CCO
-381,381,1-propanol__tert-butyl ethyl ether,19,0,0,0,0,0,0,19,1-propanol,tert-butyl ethyl ether,CCCO,CCOC(C)(C)C
-382,382,1-pentanol__2-methyl-1-propanol,19,0,0,0,0,0,0,19,1-pentanol,2-methyl-1-propanol,CCCCCO,CC(C)CO
-631,631,"butane, 2,2-dimethyl-__ether, dipropyl",0,0,0,0,19,0,0,19,"butane, 2,2-dimethyl-","ether, dipropyl",CCC(C)(C)C,CCCOCCC
-634,634,methanol__methoxymethane,0,0,0,0,19,0,0,19,methanol,methoxymethane,CO,COC
-637,637,1-propanol__methoxymethane,0,0,0,0,19,0,0,19,1-propanol,methoxymethane,CCCO,COC
-639,639,ethanol__methoxymethane,0,0,0,0,19,0,0,19,ethanol,methoxymethane,CCO,COC
-640,640,1-butanol__methoxymethane,0,0,0,0,19,0,0,19,1-butanol,methoxymethane,CCCCO,COC
-644,644,ethanol__tetrahydropyran,0,0,0,0,19,0,0,19,ethanol,tetrahydropyran,CCO,C1CCOCC1
-647,647,1-pentanol__hexane,0,0,0,0,18,0,0,18,1-pentanol,hexane,CCCCCO,CCCCCC
-653,653,2-methyl-1-propanol__1-methyl-1-(1-methylethoxy)ethane,0,0,0,0,17,0,0,17,2-methyl-1-propanol,1-methyl-1-(1-methylethoxy)ethane,CC(C)CO,CC(C)OC(C)C
-388,388,methanol__dioxane,16,0,0,0,0,0,0,16,methanol,dioxane,CO,C1COCCO1
-466,466,tert-pentyl alcohol__water,0,16,0,0,0,0,0,16,tert-pentyl alcohol,water,CCC(C)(C)O,O
-576,576,2-methoxyethanol__water,0,0,16,0,0,0,0,16,2-methoxyethanol,water,COCCO,O
-655,655,1-propanol__heptane,0,0,0,0,16,0,0,16,1-propanol,heptane,CCCO,CCCCCCC
-467,467,"1-butanol, 3-methyl-__water",0,15,0,0,0,0,0,15,"1-butanol, 3-methyl-",water,CC(C)CCO,O
-468,468,2-methyl-1-butanol__water,0,15,0,0,0,0,0,15,2-methyl-1-butanol,water,CCC(C)CO,O
-401,401,ethanol__oxane,13,0,0,0,0,0,0,13,ethanol,oxane,CCO,C1CCOCC1
-469,469,pentan-2-ol__water,0,13,0,0,0,0,0,13,pentan-2-ol,water,CCCC(C)O,O
-662,662,1-butanol__1-methyl-1-(1-methylethoxy)ethane,0,0,0,0,13,0,0,13,1-butanol,1-methyl-1-(1-methylethoxy)ethane,CCCCO,CC(C)OC(C)C
-415,415,"1,3-dioxolane__water",12,0,0,0,0,0,0,12,"1,3-dioxolane",water,C1COCO1,O
-421,421,2-propanol__methane,12,0,0,0,0,0,0,12,2-propanol,methane,CC(C)O,C
-423,423,methanol__tetrahydrofuran,12,0,0,0,0,0,0,12,methanol,tetrahydrofuran,CO,C1CCOC1
-664,664,1-methyl-1-(1-methylethoxy)ethane__heptane,0,0,0,0,12,0,0,12,1-methyl-1-(1-methylethoxy)ethane,heptane,CC(C)OC(C)C,CCCCCCC
-669,669,1-hexanol__cyclopentane,0,0,0,0,11,0,0,11,1-hexanol,cyclopentane,CCCCCCO,C1CCCC1
-443,443,2-propanol__ethane,10,0,0,0,0,0,0,10,2-propanol,ethane,CC(C)O,CC
-471,471,3-methyl-2-butanol__water,0,10,0,0,0,0,0,10,3-methyl-2-butanol,water,CC(C)C(C)O,O
-585,585,isopropyl ether__hexane,0,0,10,0,0,0,0,10,isopropyl ether,hexane,CC(C)OC(C)C,CCCCCC
-586,586,isopropyl ether__heptane,0,0,10,0,0,0,0,10,isopropyl ether,heptane,CC(C)OC(C)C,CCCCCCC
-672,672,pentan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,pentan-1-ol,tert-pentyl alcohol,CCCCCO,CCC(C)(C)O
-676,676,ethanol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,ethanol,tert-pentyl alcohol,CCO,CCC(C)(C)O
-677,677,butan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,butan-1-ol,tert-pentyl alcohol,CCCCO,CCC(C)(C)O
-683,683,propan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,propan-1-ol,tert-pentyl alcohol,CCCO,CCC(C)(C)O
-686,686,methanol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,methanol,tert-pentyl alcohol,CO,CCC(C)(C)O
-445,445,(RS)-2-butanol__water,9,0,0,0,0,0,0,9,(RS)-2-butanol,water,CCC(C)O,O
-588,588,isopropyl ether__cyclohexane,0,0,9,0,0,0,0,9,isopropyl ether,cyclohexane,CC(C)OC(C)C,C1CCCCC1
-688,688,1-pentanol__tetrahydropyran,0,0,0,0,9,0,0,9,1-pentanol,tetrahydropyran,CCCCCO,C1CCOCC1
-691,691,"1,4-dioxane__tetrahydropyran",0,0,0,0,9,0,0,9,"1,4-dioxane",tetrahydropyran,C1COCCO1,C1CCOCC1
-453,453,isopropyl ether__isooctane,8,0,0,0,0,0,0,8,isopropyl ether,isooctane,CC(C)OC(C)C,CCCCCC(C)C
-460,460,methanol__2-methoxyethanol,5,0,0,0,0,0,0,5,methanol,2-methoxyethanol,CO,COCCO
-494,494,tert-amyl methyl ether__water,0,4,0,0,0,0,0,4,tert-amyl methyl ether,water,CCC(C)(C)OC,O
-496,496,tert-butyl ethyl ether__water,0,4,0,0,0,0,0,4,tert-butyl ethyl ether,water,CCOC(C)(C)C,O
-464,464,methanol__ethane,3,0,0,0,0,0,0,3,methanol,ethane,CO,CC
-538,538,methylcyclopentane__methyl cellosolve,0,1,0,0,0,0,0,1,methylcyclopentane,methyl cellosolve,CC1CCCC1,COCCO
-540,540,methyl cellosolve__cyclohexane,0,1,0,0,0,0,0,1,methyl cellosolve,cyclohexane,COCCO,C1CCCCC1
-541,541,methyl cellosolve__cyclooctane,0,1,0,0,0,0,0,1,methyl cellosolve,cyclooctane,COCCO,C1CCCCCCC1
-543,543,methylcyclohexane__methyl cellosolve,0,1,0,0,0,0,0,1,methylcyclohexane,methyl cellosolve,CC1CCCCC1,COCCO
-559,559,methyl cellosolve__n-heptane,0,1,0,0,0,0,0,1,methyl cellosolve,n-heptane,COCCO,CCCCCCC
-560,560,methyl cellosolve__n-hexane,0,1,0,0,0,0,0,1,methyl cellosolve,n-hexane,COCCO,CCCCCC
+,Mixture,Mixture Count dens binary,Mixture Count actcoeff binary,Mixture Count sos binary,Mixture Count dielec binary,Mixture Count eme binary,Mixture Count emcp binary,Mixture Count emv binary,Mixture Count all,x1,x2,SMILES1,SMILES2
+0,benzene__octane,1067,0,13,0,0,0,0,1080,benzene,octane,c1ccccc1,CCCCCCCC
+2,2-propanol__water,1012,0,0,0,45,0,0,1057,2-propanol,water,CC(C)O,O
+3,1-propanol__toluene,842,0,0,0,0,0,0,842,1-propanol,toluene,CCCO,Cc1ccccc1
+9,ethanol__water,712,0,20,0,83,0,0,815,ethanol,water,CCO,O
+8,ethanol__toluene,723,0,71,0,0,0,0,794,ethanol,toluene,CCO,Cc1ccccc1
+5,ethanol__methylcyclohexane,753,0,11,0,0,0,0,764,ethanol,methylcyclohexane,CCO,CC1CCCCC1
+4,1-heptanol__heptane,756,0,0,0,0,0,0,756,1-heptanol,heptane,CCCCCCCO,CCCCCCC
+10,ethanol__heptane,708,0,39,0,0,0,0,747,ethanol,heptane,CCO,CCCCCCC
+11,2-methyl-2-propanol__water,636,0,6,0,0,0,0,642,2-methyl-2-propanol,water,CC(C)(C)O,O
+12,1-butanol__cyclohexane,501,0,51,0,38,0,0,590,1-butanol,cyclohexane,CCCCO,C1CCCCC1
+89,tert-pentyl alcohol__heptane,102,0,450,0,0,0,0,552,tert-pentyl alcohol,heptane,CCC(C)(C)O,CCCCCCC
+63,"1,4-butanediol__water",142,0,142,0,36,109,109,538,"1,4-butanediol",water,OCCCCO,O
+17,1-propoxy-2-propanol__water,318,0,145,0,0,0,0,463,1-propoxy-2-propanol,water,CCCOCC(C)O,O
+13,glycerol__water,381,5,0,8,0,0,0,394,glycerol,water,OCC(O)CO,O
+38,"1,2-dimethylbenzene__methyl tert-butyl ether",195,0,195,0,0,0,0,390,"1,2-dimethylbenzene",methyl tert-butyl ether,Cc1ccccc1C,COC(C)(C)C
+39,"1,3-dimethylbenzene__tert-butyl ethyl ether",195,0,195,0,0,0,0,390,"1,3-dimethylbenzene",tert-butyl ethyl ether,Cc1cccc(C)c1,CCOC(C)(C)C
+40,"1,3-dimethylbenzene__methyl tert-butyl ether",195,0,195,0,0,0,0,390,"1,3-dimethylbenzene",methyl tert-butyl ether,Cc1cccc(C)c1,COC(C)(C)C
+41,"1,2-dimethylbenzene__tert-butyl ethyl ether",195,0,195,0,0,0,0,390,"1,2-dimethylbenzene",tert-butyl ethyl ether,Cc1ccccc1C,CCOC(C)(C)C
+42,"1,4-dimethylbenzene__methyl tert-butyl ether",195,0,195,0,0,0,0,390,"1,4-dimethylbenzene",methyl tert-butyl ether,Cc1ccc(C)cc1,COC(C)(C)C
+43,"1,4-dimethylbenzene__tert-butyl ethyl ether",195,0,195,0,0,0,0,390,"1,4-dimethylbenzene",tert-butyl ethyl ether,Cc1ccc(C)cc1,CCOC(C)(C)C
+33,methanol__water,212,0,12,0,140,0,0,364,methanol,water,CO,O
+14,tert-butanol__water,360,0,0,0,0,0,0,360,tert-butanol,water,CC(C)(C)O,O
+27,1-hexanol__dibutyl ether,254,0,54,0,20,0,0,328,1-hexanol,dibutyl ether,CCCCCCO,CCCCOCCCC
+15,"1,1,1-trimethanolethane__water",324,0,0,0,0,0,0,324,"1,1,1-trimethanolethane",water,CC(CO)(CO)CO,O
+16,n-butyl alcohol__2-methylheptane,324,0,0,0,0,0,0,324,n-butyl alcohol,2-methylheptane,CCCCO,CCCCCC(C)C
+25,benzene__cyclohexane,262,0,44,0,0,0,0,306,benzene,cyclohexane,c1ccccc1,C1CCCCC1
+84,"1,3-propanediol__water",106,0,0,8,36,64,90,304,"1,3-propanediol",water,OCCCO,O
+18,n-butyl alcohol__butyl oxide,300,0,0,0,0,0,0,300,n-butyl alcohol,butyl oxide,CCCCO,CCCCOCCCC
+21,cyclohexanol__water,280,0,15,0,0,0,0,295,cyclohexanol,water,OC1CCCCC1,O
+19,cyclopentanol__water,287,0,0,0,0,0,0,287,cyclopentanol,water,OC1CCCC1,O
+20,bis(2-hydroxyethyl) ether__water,280,0,0,0,0,0,0,280,bis(2-hydroxyethyl) ether,water,OCCOCCO,O
+22,cis-decalin__trans-decalin,278,0,0,0,0,0,0,278,cis-decalin,trans-decalin,C1CC[C@@H]2CCCC[C@@H]2C1,C1CC[C@@H]2CCCC[C@H]2C1
+71,.beta.-butylene glycol__water,138,0,138,0,0,0,0,276,.beta.-butylene glycol,water,CC(O)CCO,O
+23,"2-ethyl-2-(hydroxymethyl)-1,3-propanediol__water",270,0,0,0,0,0,0,270,"2-ethyl-2-(hydroxymethyl)-1,3-propanediol",water,CCC(CO)(CO)CO,O
+24,"1,5-pentanediol__water",269,0,0,0,0,0,0,269,"1,5-pentanediol",water,OCCCCCO,O
+354,"1,2-propanediol__water",22,0,0,8,36,85,114,265,"1,2-propanediol",water,CC(O)CO,O
+26,"1,6-hexanediol__water",255,0,0,0,0,0,0,255,"1,6-hexanediol",water,OCCCCCCO,O
+75,"1-heptanol__1,4-dioxane",126,0,126,0,0,0,0,252,1-heptanol,"1,4-dioxane",CCCCCCCO,C1COCCO1
+333,"1,2-ethanediol__water",26,0,0,10,0,79,135,250,"1,2-ethanediol",water,OCCO,O
+184,ethanol__methanol,63,0,0,105,76,0,0,244,ethanol,methanol,CCO,CO
+28,"1,4-dimethylbenzene__octane",242,0,0,0,0,0,0,242,"1,4-dimethylbenzene",octane,Cc1ccc(C)cc1,CCCCCCCC
+31,tetrahydrofuran__water,220,0,20,0,0,0,0,240,tetrahydrofuran,water,C1CCOC1,O
+29,cycloheptanol__water,222,0,0,0,0,0,0,222,cycloheptanol,water,OC1CCCCCC1,O
+35,1-propanol__dibutyl ether,200,0,0,0,21,0,0,221,1-propanol,dibutyl ether,CCCO,CCCCOCCCC
+30,"1,8-octanediol__water",220,0,0,0,0,0,0,220,"1,8-octanediol",water,OCCCCCCCCO,O
+108,1-butanol__toluene,88,0,88,0,38,0,0,214,1-butanol,toluene,CCCCO,Cc1ccccc1
+32,neopentyl alcohol__water,213,0,0,0,0,0,0,213,neopentyl alcohol,water,CC(C)(C)CO,O
+46,"1,4-dimethylbenzene__decane",180,0,33,0,0,0,0,213,"1,4-dimethylbenzene",decane,Cc1ccc(C)cc1,CCCCCCCCCC
+96,"1-butanol__2,2,4-trimethylpentane",93,0,80,0,38,0,0,211,1-butanol,"2,2,4-trimethylpentane",CCCCO,CC(C)CC(C)(C)C
+34,"2-methyl-1,3-propanediol__water",209,0,0,0,0,0,0,209,"2-methyl-1,3-propanediol",water,CC(CO)CO,O
+44,2-butoxyethanol__water,191,0,18,0,0,0,0,209,2-butoxyethanol,water,CCCCOCCO,O
+95,"1,2-hexanediol__water",96,0,0,0,0,53,60,209,"1,2-hexanediol",water,CCCCC(O)CO,O
+45,decane__methyl tert-butyl ether,181,0,0,0,20,0,0,201,decane,methyl tert-butyl ether,CCCCCCCCCC,COC(C)(C)C
+36,2-propanol__dibutyl ether,200,0,0,0,0,0,0,200,2-propanol,dibutyl ether,CC(C)O,CCCCOCCCC
+51,1-propanol__water,172,0,27,0,0,0,0,199,1-propanol,water,CCCO,O
+37,"3,6-dioxaoctane__water",196,0,0,0,0,0,0,196,"3,6-dioxaoctane",water,CCOCCOCC,O
+74,2-phenylethanol__2-propanol,129,0,66,0,0,0,0,195,2-phenylethanol,2-propanol,OCCc1ccccc1,CC(C)O
+205,1-butanol__dibutyl ether,55,0,55,0,84,0,0,194,1-butanol,dibutyl ether,CCCCO,CCCCOCCCC
+49,nonane__methyl tert-butyl ether,173,0,0,0,20,0,0,193,nonane,methyl tert-butyl ether,CCCCCCCCC,COC(C)(C)C
+70,1-butanol__benzene,138,0,0,0,51,0,0,189,1-butanol,benzene,CCCCO,c1ccccc1
+47,cyclohexylmethanol__water,176,0,0,0,0,0,0,176,cyclohexylmethanol,water,OCC1CCCCC1,O
+48,2-cyclohexylethanol__water,175,0,0,0,0,0,0,175,2-cyclohexylethanol,water,OCCC1CCCCC1,O
+186,1-butanol__hexane,60,0,60,0,23,0,31,174,1-butanol,hexane,CCCCO,CCCCCC
+50,diethoxymethane__water,173,0,0,0,0,0,0,173,diethoxymethane,water,CCOCOCC,O
+57,"2,5,8-trioxanonane__water",154,0,18,0,0,0,0,172,"2,5,8-trioxanonane",water,COCCOCCOC,O
+59,"ethanol__2,2,4-trimethylpentane",150,0,0,0,19,0,0,169,ethanol,"2,2,4-trimethylpentane",CCO,CC(C)CC(C)(C)C
+53,pentaerythritol__water,165,0,0,0,0,0,0,165,pentaerythritol,water,OCC(CO)(CO)CO,O
+127,2-propanol__cyclohexane,78,0,78,0,9,0,0,165,2-propanol,cyclohexane,CC(C)O,C1CCCCC1
+123,1-octanol__1-butoxy-2-propanol,80,0,80,0,0,0,0,160,1-octanol,1-butoxy-2-propanol,CCCCCCCCO,CCCCOCC(C)O
+124,1-hexanol__1-butoxy-2-propanol,80,0,80,0,0,0,0,160,1-hexanol,1-butoxy-2-propanol,CCCCCCO,CCCCOCC(C)O
+55,cyclooctanol__water,156,0,0,0,0,0,0,156,cyclooctanol,water,OC1CCCCCCC1,O
+56,"2,2-dimethyl-1,3-propanediol__water",156,0,0,0,0,0,0,156,"2,2-dimethyl-1,3-propanediol",water,CC(C)(CO)CO,O
+137,"toluene__2,2,4-trimethylpentane",77,0,77,0,0,0,0,154,toluene,"2,2,4-trimethylpentane",Cc1ccccc1,CC(C)CC(C)(C)C
+58,methanol__methyl tert-butyl ether,151,0,0,0,0,0,0,151,methanol,methyl tert-butyl ether,CO,COC(C)(C)C
+80,ethanol__cyclohexane,111,0,39,0,0,0,0,150,ethanol,cyclohexane,CCO,C1CCCCC1
+141,"dibutyl ether__ethanol, 2-propoxy-",73,0,73,0,0,0,0,146,dibutyl ether,"ethanol, 2-propoxy-",CCCCOCCCC,CCCOCCO
+61,2-propanol__methyl tert-butyl ether,144,0,0,0,0,0,0,144,2-propanol,methyl tert-butyl ether,CC(C)O,COC(C)(C)C
+62,butan-1-ol__methyl tert-butyl ether,144,0,0,0,0,0,0,144,butan-1-ol,methyl tert-butyl ether,CCCCO,COC(C)(C)C
+143,ethanol__isooctane,72,0,72,0,0,0,0,144,ethanol,isooctane,CCO,CCCCCC(C)C
+214,"butan-1-ol__butane, 1,4-dihydroxy-",50,0,54,0,0,0,40,144,butan-1-ol,"butane, 1,4-dihydroxy-",CCCCO,OCCCCO
+64,propan-1-ol__methyl tert-butyl ether,140,0,0,0,0,0,0,140,propan-1-ol,methyl tert-butyl ether,CCCO,COC(C)(C)C
+65,ethanol__methyl tert-butyl ether,140,0,0,0,0,0,0,140,ethanol,methyl tert-butyl ether,CCO,COC(C)(C)C
+66,pentan-1-ol__methyl tert-butyl ether,140,0,0,0,0,0,0,140,pentan-1-ol,methyl tert-butyl ether,CCCCCO,COC(C)(C)C
+67,pentylcarbinol__methyl tert-butyl ether,140,0,0,0,0,0,0,140,pentylcarbinol,methyl tert-butyl ether,CCCCCCO,COC(C)(C)C
+145,2-butoxyethanol__1-octanol,70,0,70,0,0,0,0,140,2-butoxyethanol,1-octanol,CCCCOCCO,CCCCCCCCO
+146,1-propanol__2-butoxyethanol,70,0,70,0,0,0,0,140,1-propanol,2-butoxyethanol,CCCO,CCCCOCCO
+147,2-butanol__2-butoxyethanol,70,0,70,0,0,0,0,140,2-butanol,2-butoxyethanol,CCC(C)O,CCCCOCCO
+148,2-propanol__2-butoxyethanol,70,0,70,0,0,0,0,140,2-propanol,2-butoxyethanol,CC(C)O,CCCCOCCO
+149,1-hexanol__2-butoxyethanol,70,0,70,0,0,0,0,140,1-hexanol,2-butoxyethanol,CCCCCCO,CCCCOCCO
+150,1-butanol__2-butoxyethanol,70,0,70,0,0,0,0,140,1-butanol,2-butoxyethanol,CCCCO,CCCCOCCO
+68,ribitol__water,139,0,0,0,0,0,0,139,ribitol,water,OC[C@@H](O)[C@@H](O)[C@@H](O)CO,O
+69,"3-methylpentane-1,5-diol__water",138,0,0,0,0,0,0,138,"3-methylpentane-1,5-diol",water,CC(CCO)CCO,O
+111,methylcyclohexane__toluene,85,0,50,0,0,0,0,135,methylcyclohexane,toluene,CC1CCCCC1,Cc1ccccc1
+113,benzene__methylcyclohexane,85,0,50,0,0,0,0,135,benzene,methylcyclohexane,c1ccccc1,CC1CCCCC1
+152,"nonane__2,5,8-trioxanonane",69,0,0,66,0,0,0,135,nonane,"2,5,8-trioxanonane",CCCCCCCCC,COCCOCCOC
+77,ethanol__2-methyl-1-butanol,116,0,18,0,0,0,0,134,ethanol,2-methyl-1-butanol,CCO,CCC(C)CO
+197,1-octanol__dibutyl ether,56,0,56,0,22,0,0,134,1-octanol,dibutyl ether,CCCCCCCCO,CCCCOCCCC
+153,1-butanol__methyl tert-butyl ether,67,0,66,0,0,0,0,133,1-butanol,methyl tert-butyl ether,CCCCO,COC(C)(C)C
+97,toluene__cyclohexane,93,0,39,0,0,0,0,132,toluene,cyclohexane,Cc1ccccc1,C1CCCCC1
+154,"benzenemethanol__1,2-butanediol",66,0,66,0,0,0,0,132,benzenemethanol,"1,2-butanediol",OCc1ccccc1,CCC(O)CO
+156,2-phenylethanol__1-propanol,66,0,66,0,0,0,0,132,2-phenylethanol,1-propanol,OCCc1ccccc1,CCCO
+157,1-propanol__tert-butanol,66,0,66,0,0,0,0,132,1-propanol,tert-butanol,CCCO,CC(C)(C)O
+159,"2-phenylethanol__1,2-butanediol",66,0,66,0,0,0,0,132,2-phenylethanol,"1,2-butanediol",OCCc1ccccc1,CCC(O)CO
+160,2-propanol__tert-butanol,66,0,66,0,0,0,0,132,2-propanol,tert-butanol,CC(C)O,CC(C)(C)O
+161,"(RS)-2-butanol__1,2-butanediol",66,0,66,0,0,0,0,132,(RS)-2-butanol,"1,2-butanediol",CCC(C)O,CCC(O)CO
+163,"1,2-dimethoxyethane__nonane",66,0,0,66,0,0,0,132,"1,2-dimethoxyethane",nonane,COCCOC,CCCCCCCCC
+165,"2-propanol__1,3-propanediol",66,0,66,0,0,0,0,132,2-propanol,"1,3-propanediol",CC(C)O,OCCCO
+171,"1,3-butanediol__1,2-butanediol",66,0,66,0,0,0,0,132,"1,3-butanediol","1,2-butanediol",CC(O)CCO,CCC(O)CO
+172,"1-propanol__1,3-propanediol",66,0,66,0,0,0,0,132,1-propanol,"1,3-propanediol",CCCO,OCCCO
+73,1-propanol__benzene,131,0,0,0,0,0,0,131,1-propanol,benzene,CCCO,c1ccccc1
+195,1-pentanol__dibutyl ether,56,0,56,0,19,0,0,131,1-pentanol,dibutyl ether,CCCCCO,CCCCOCCCC
+697,"1-butanol__1,4-butanediol",0,0,0,0,0,130,0,130,1-butanol,"1,4-butanediol",CCCCO,OCCCCO
+176,octane__methyl tert-butyl ether,64,0,65,0,0,0,0,129,octane,methyl tert-butyl ether,CCCCCCCC,COC(C)(C)C
+179,1-butanol__2-(2-methoxyethoxy)ethanol,63,0,63,0,0,0,0,126,1-butanol,2-(2-methoxyethoxy)ethanol,CCCCO,COCCOCCO
+185,2-methoxyethanol__2-(2-methoxyethoxy)ethanol,61,0,61,0,0,0,0,122,2-methoxyethanol,2-(2-methoxyethoxy)ethanol,COCCO,COCCOCCO
+76,methanol__benzene,121,0,0,0,0,0,0,121,methanol,benzene,CO,c1ccccc1
+189,"1-butanol__3,6-dioxa-1-octanol",60,0,60,0,0,0,0,120,1-butanol,"3,6-dioxa-1-octanol",CCCCO,CCOCCOCCO
+266,ethanol__hexane,39,0,39,0,17,0,23,118,ethanol,hexane,CCO,CCCCCC
+78,"2,5-hexanediol__water",114,0,0,0,0,0,0,114,"2,5-hexanediol",water,CC(O)CCC(C)O,O
+192,2-methoxyethanol__2-butoxyethanol,57,0,57,0,0,0,0,114,2-methoxyethanol,2-butoxyethanol,COCCO,CCCCOCCO
+281,benzene__tetrahydropyran,36,0,50,0,14,0,14,114,benzene,tetrahydropyran,c1ccccc1,C1CCOCC1
+284,toluene__tetrahydropyran,36,0,50,0,14,0,14,114,toluene,tetrahydropyran,Cc1ccccc1,C1CCOCC1
+228,1-butanol__octane,48,0,48,0,16,0,0,112,1-butanol,octane,CCCCO,CCCCCCCC
+199,"2,2,4-trimethylpentane__methyl tert-butyl ether",55,0,55,0,0,0,0,110,"2,2,4-trimethylpentane",methyl tert-butyl ether,CC(C)CC(C)(C)C,COC(C)(C)C
+200,1-heptanol__dibutyl ether,55,0,55,0,0,0,0,110,1-heptanol,dibutyl ether,CCCCCCCO,CCCCOCCCC
+81,"1-propanol__2,2,4-trimethylpentane",108,0,0,0,0,0,0,108,1-propanol,"2,2,4-trimethylpentane",CCCO,CC(C)CC(C)(C)C
+83,glycerin__water,107,0,0,0,0,0,0,107,glycerin,water,OCC(O)CO,O
+100,2-(2-methoxyethoxy)ethanol__water,91,0,16,0,0,0,0,107,2-(2-methoxyethoxy)ethanol,water,COCCOCCO,O
+121,"1,4-dimethylbenzene__cyclohexane",81,0,26,0,0,0,0,107,"1,4-dimethylbenzene",cyclohexane,Cc1ccc(C)cc1,C1CCCCC1
+142,"1,3-benzenediol__water",72,0,35,0,0,0,0,107,"1,3-benzenediol",water,Oc1cccc(O)c1,O
+85,propylene glycol__water,106,0,0,0,0,0,0,106,propylene glycol,water,CC(O)CO,O
+118,"2,2-bis(hydroxymethyl)-1,3-propanediol__water",84,0,22,0,0,0,0,106,"2,2-bis(hydroxymethyl)-1,3-propanediol",water,OCC(CO)(CO)CO,O
+86,methanol__ethylbenzene,105,0,0,0,0,0,0,105,methanol,ethylbenzene,CO,CCc1ccccc1
+87,2-methoxyethanol__tert-butyl ethyl ether,105,0,0,0,0,0,0,105,2-methoxyethanol,tert-butyl ethyl ether,COCCO,CCOC(C)(C)C
+88,2-(2-methoxyethoxy)ethanol__tert-butyl ethyl ether,105,0,0,0,0,0,0,105,2-(2-methoxyethoxy)ethanol,tert-butyl ethyl ether,COCCOCCO,CCOC(C)(C)C
+592,methanol__2-propanol,0,0,0,105,0,0,0,105,methanol,2-propanol,CO,CC(C)O
+593,methanol__2-methyl-1-propanol,0,0,0,105,0,0,0,105,methanol,2-methyl-1-propanol,CO,CC(C)CO
+594,methanol__1-butanol,0,0,0,105,0,0,0,105,methanol,1-butanol,CO,CCCCO
+595,methanol__1-propanol,0,0,0,105,0,0,0,105,methanol,1-propanol,CO,CCCO
+193,toluene__methyl tert-butyl ether,57,0,46,0,0,0,0,103,toluene,methyl tert-butyl ether,Cc1ccccc1,COC(C)(C)C
+233,"1,2-ethanediol__1-nonanol",48,0,55,0,0,0,0,103,"1,2-ethanediol",1-nonanol,OCCO,CCCCCCCCCO
+177,1-propanol__cyclopentane,63,0,39,0,0,0,0,102,1-propanol,cyclopentane,CCCO,C1CCCC1
+105,toluene__octane,88,0,13,0,0,0,0,101,toluene,octane,Cc1ccccc1,CCCCCCCC
+91,tetralin__isobutylbenzene,100,0,0,0,0,0,0,100,tetralin,isobutylbenzene,C1CCc2ccccc2C1,CC(C)Cc1ccccc1
+92,heptane__methyl tert-butyl ether,99,0,0,0,0,0,0,99,heptane,methyl tert-butyl ether,CCCCCCC,COC(C)(C)C
+93,ethanol__3-methyl-1-butanol,98,0,0,0,0,0,0,98,ethanol,3-methyl-1-butanol,CCO,CC(C)CCO
+94,ethanol__2-methyl-2-butanol,98,0,0,0,0,0,0,98,ethanol,2-methyl-2-butanol,CCO,CCC(C)(C)O
+190,"1,4-dimethylbenzene__methylcyclohexane",59,0,37,0,0,0,0,96,"1,4-dimethylbenzene",methylcyclohexane,Cc1ccc(C)cc1,CC1CCCCC1
+191,"1,3,5-trimethylbenzene__methylcyclohexane",59,0,37,0,0,0,0,96,"1,3,5-trimethylbenzene",methylcyclohexane,Cc1cc(C)cc(C)c1,CC1CCCCC1
+215,ethylbenzene__1-nonanol,48,0,48,0,0,0,0,96,ethylbenzene,1-nonanol,CCc1ccccc1,CCCCCCCCCO
+216,benzene__2-ethyl-1-hexanol,48,0,48,0,0,0,0,96,benzene,2-ethyl-1-hexanol,c1ccccc1,CCCCC(CC)CO
+217,2-methoxyethanol__1-octanol,48,0,48,0,0,0,0,96,2-methoxyethanol,1-octanol,COCCO,CCCCCCCCO
+218,"1,3-dimethylbenzene__1-nonanol",48,0,48,0,0,0,0,96,"1,3-dimethylbenzene",1-nonanol,Cc1cccc(C)c1,CCCCCCCCCO
+223,2-methoxyethanol__1-hexanol,48,0,48,0,0,0,0,96,2-methoxyethanol,1-hexanol,COCCO,CCCCCCO
+224,"1,4-dimethylbenzene__1-nonanol",48,0,48,0,0,0,0,96,"1,4-dimethylbenzene",1-nonanol,Cc1ccc(C)cc1,CCCCCCCCCO
+225,tetrahydrofuran__n-hexyl alcohol,48,0,48,0,0,0,0,96,tetrahydrofuran,n-hexyl alcohol,C1CCOC1,CCCCCCO
+226,octane__1-octanol,48,0,48,0,0,0,0,96,octane,1-octanol,CCCCCCCC,CCCCCCCCO
+229,1-octanol__decane,48,0,48,0,0,0,0,96,1-octanol,decane,CCCCCCCCO,CCCCCCCCCC
+230,hexane__1-octanol,48,0,48,0,0,0,0,96,hexane,1-octanol,CCCCCC,CCCCCCCCO
+232,1-butanol__decane,48,0,48,0,0,0,0,96,1-butanol,decane,CCCCO,CCCCCCCCCC
+235,"1,2-dimethylbenzene__1-nonanol",48,0,48,0,0,0,0,96,"1,2-dimethylbenzene",1-nonanol,Cc1ccccc1C,CCCCCCCCCO
+236,tetrahydrofuran__octyl alcohol,48,0,48,0,0,0,0,96,tetrahydrofuran,octyl alcohol,C1CCOC1,CCCCCCCCO
+596,methanol__2-methyl-2-propanol,0,0,0,95,0,0,0,95,methanol,2-methyl-2-propanol,CO,CC(C)(C)O
+138,1-butanol__water,75,8,11,0,0,0,0,94,1-butanol,water,CCCCO,O
+320,1-butanol__2-methyltetrahydrofuran,27,0,34,0,33,0,0,94,1-butanol,2-methyltetrahydrofuran,CCCCO,CC1CCCO1
+98,"1,2-dimethoxyethane__water",93,0,0,0,0,0,0,93,"1,2-dimethoxyethane",water,COCCOC,O
+203,1-butanol__heptane,55,0,0,0,38,0,0,93,1-butanol,heptane,CCCCO,CCCCCCC
+99,"benzene__2,2,4-trimethylpentane",92,0,0,0,0,0,0,92,benzene,"2,2,4-trimethylpentane",c1ccccc1,CC(C)CC(C)(C)C
+209,ethylbenzene__methylcyclohexane,52,0,39,0,0,0,0,91,ethylbenzene,methylcyclohexane,CCc1ccccc1,CC1CCCCC1
+101,oxacyclopentane__water,90,0,0,0,0,0,0,90,oxacyclopentane,water,C1CCOC1,O
+241,2-butoxyethan-1-ol__water,45,0,45,0,0,0,0,90,2-butoxyethan-1-ol,water,CCCCOCCO,O
+245,2-(2-methylpropoxy)ethanol__water,45,0,45,0,0,0,0,90,2-(2-methylpropoxy)ethanol,water,CC(C)COCCO,O
+213,1-propanol__cyclohexane,50,0,39,0,0,0,0,89,1-propanol,cyclohexane,CCCO,C1CCCCC1
+269,1-butanol__cyclopentane,39,0,39,0,11,0,0,89,1-butanol,cyclopentane,CCCCO,C1CCCC1
+102,ethyl alcohol__n-butyl alcohol,88,0,0,0,0,0,0,88,ethyl alcohol,n-butyl alcohol,CCO,CCCCO
+103,"glycerol__1,2-propanediol",88,0,0,0,0,0,0,88,glycerol,"1,2-propanediol",OCC(O)CO,CC(O)CO
+104,"glycerol__1,3-propanediol",88,0,0,0,0,0,0,88,glycerol,"1,3-propanediol",OCC(O)CO,OCCCO
+106,glycerol__2-propanol,88,0,0,0,0,0,0,88,glycerol,2-propanol,OCC(O)CO,CC(C)O
+107,ethyl alcohol__pentan-1-ol,88,0,0,0,0,0,0,88,ethyl alcohol,pentan-1-ol,CCO,CCCCCO
+109,ethyl alcohol__propan-1-ol,88,0,0,0,0,0,0,88,ethyl alcohol,propan-1-ol,CCO,CCCO
+110,glycerol__1-propanol,88,0,0,0,0,0,0,88,glycerol,1-propanol,OCC(O)CO,CCCO
+246,"2-methoxyethanol__ethanol, 2-ethoxy-",44,0,44,0,0,0,0,88,2-methoxyethanol,"ethanol, 2-ethoxy-",COCCO,CCOCCO
+112,"1,2-dihydroxyethane__water",85,0,0,0,0,0,0,85,"1,2-dihydroxyethane",water,OCCO,O
+140,"2-propanol__1,3-dioxolane",74,0,11,0,0,0,0,85,2-propanol,"1,3-dioxolane",CC(C)O,C1COCO1
+114,"2-propanol__pentane, 2,2,4-trimethyl-",84,0,0,0,0,0,0,84,2-propanol,"pentane, 2,2,4-trimethyl-",CC(C)O,CC(C)CC(C)(C)C
+115,"tetrahydropyran__pentane, 2,2,4-trimethyl-",84,0,0,0,0,0,0,84,tetrahydropyran,"pentane, 2,2,4-trimethyl-",C1CCOCC1,CC(C)CC(C)(C)C
+116,"1-hexanol__2,2,4-trimethylpentane",84,0,0,0,0,0,0,84,1-hexanol,"2,2,4-trimethylpentane",CCCCCCO,CC(C)CC(C)(C)C
+117,"1-heptanol__2,2,4-trimethylpentane",84,0,0,0,0,0,0,84,1-heptanol,"2,2,4-trimethylpentane",CCCCCCCO,CC(C)CC(C)(C)C
+119,2-propanol__tetrahydropyran,84,0,0,0,0,0,0,84,2-propanol,tetrahydropyran,CC(C)O,C1CCOCC1
+120,ethanol__benzyl alcohol,84,0,0,0,0,0,0,84,ethanol,benzyl alcohol,CCO,OCc1ccccc1
+252,toluene__2-hexanol,42,0,42,0,0,0,0,84,toluene,2-hexanol,Cc1ccccc1,CCCCC(C)O
+255,toluene__2-heptanol,42,0,42,0,0,0,0,84,toluene,2-heptanol,Cc1ccccc1,CCCCCC(C)O
+257,toluene__2-octanol,42,0,42,0,0,0,0,84,toluene,2-octanol,Cc1ccccc1,CCCCCCC(C)O
+305,1-butanol__methylcyclohexane,33,0,11,0,38,0,0,82,1-butanol,methylcyclohexane,CCCCO,CC1CCCCC1
+122,1-butanol__2-methyl-1-propanol,81,0,0,0,0,0,0,81,1-butanol,2-methyl-1-propanol,CCCCO,CC(C)CO
+261,"1,2-benzenediol__water",40,0,40,0,0,0,0,80,"1,2-benzenediol",water,Oc1ccccc1O,O
+125,2-methyl-1-propanol__water,79,0,0,0,0,0,0,79,2-methyl-1-propanol,water,CC(C)CO,O
+126,"1-pentanol__2,2,4-trimethylpentane",79,0,0,0,0,0,0,79,1-pentanol,"2,2,4-trimethylpentane",CCCCCO,CC(C)CC(C)(C)C
+263,2-propanol__cyclopentane,39,0,39,0,0,0,0,78,2-propanol,cyclopentane,CC(C)O,C1CCCC1
+264,ethanol__cyclopentane,39,0,39,0,0,0,0,78,ethanol,cyclopentane,CCO,C1CCCC1
+265,toluene__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,toluene,tert-butyl ethyl ether,Cc1ccccc1,CCOC(C)(C)C
+267,"bis(2-hydroxyethyl) ether__ethanol, 2-propoxy-",39,0,0,39,0,0,0,78,bis(2-hydroxyethyl) ether,"ethanol, 2-propoxy-",OCCOCCO,CCCOCCO
+268,"triethylene glycol__ethanol, 2-propoxy-",39,0,0,39,0,0,0,78,triethylene glycol,"ethanol, 2-propoxy-",OCCOCCOCCO,CCCOCCO
+271,ethylbenzene__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,ethylbenzene,tert-butyl ethyl ether,CCc1ccccc1,CCOC(C)(C)C
+272,benzene__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,benzene,tert-butyl ethyl ether,c1ccccc1,CCOC(C)(C)C
+273,ethylbenzene__cyclohexane,39,0,39,0,0,0,0,78,ethylbenzene,cyclohexane,CCc1ccccc1,C1CCCCC1
+274,2-methyl-2-propanol__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,2-methyl-2-propanol,tert-butyl ethyl ether,CC(C)(C)O,CCOC(C)(C)C
+275,"2,2,4-trimethylpentane__tert-butyl ethyl ether",39,0,39,0,0,0,0,78,"2,2,4-trimethylpentane",tert-butyl ethyl ether,CC(C)CC(C)(C)C,CCOC(C)(C)C
+276,cyclopentane__2-pentanol,39,0,39,0,0,0,0,78,cyclopentane,2-pentanol,C1CCCC1,CCCC(C)O
+277,2-methyl-2-butanol__tetrahydrofuran,39,0,0,0,0,0,39,78,2-methyl-2-butanol,tetrahydrofuran,CCC(C)(C)O,C1CCOC1
+279,ethanol__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,ethanol,tert-butyl ethyl ether,CCO,CCOC(C)(C)C
+128,"1,2-ethanediol__3-methylphenol",77,0,0,0,0,0,0,77,"1,2-ethanediol",3-methylphenol,OCCO,Cc1cccc(O)c1
+130,ethanol__n-octane,77,0,0,0,0,0,0,77,ethanol,n-octane,CCO,CCCCCCCC
+131,1-butanol__n-octane,77,0,0,0,0,0,0,77,1-butanol,n-octane,CCCCO,CCCCCCCC
+132,1-pentanol__n-octane,77,0,0,0,0,0,0,77,1-pentanol,n-octane,CCCCCO,CCCCCCCC
+133,1-octanol__1-nonanol,77,0,0,0,0,0,0,77,1-octanol,1-nonanol,CCCCCCCCO,CCCCCCCCCO
+135,"4-methylphenol__1,2-ethanediol",77,0,0,0,0,0,0,77,4-methylphenol,"1,2-ethanediol",Cc1ccc(O)cc1,OCCO
+136,1-propanol__n-octane,77,0,0,0,0,0,0,77,1-propanol,n-octane,CCCO,CCCCCCCC
+600,ethanol__2-propanol,0,0,0,0,76,0,0,76,ethanol,2-propanol,CCO,CC(C)O
+139,"1,5-hexanediol__water",75,0,0,0,0,0,0,75,"1,5-hexanediol",water,CC(O)CCCCO,O
+601,ethanol__1-propanol,0,0,0,0,74,0,0,74,ethanol,1-propanol,CCO,CCCO
+144,1-butanol__2-methyl-2-propanol,72,0,0,0,0,0,0,72,1-butanol,2-methyl-2-propanol,CCCCO,CC(C)(C)O
+282,o-xylene__tetrahydropyran,36,0,36,0,0,0,0,72,o-xylene,tetrahydropyran,Cc1ccccc1C,C1CCOCC1
+151,tert-butanol__heptane,70,0,0,0,0,0,0,70,tert-butanol,heptane,CC(C)(C)O,CCCCCCC
+566,1-butanol__tetrahydropyran,0,0,35,0,33,0,0,68,1-butanol,tetrahydropyran,CCCCO,C1CCOCC1
+288,"2,5,8-trioxanonane__heptane",34,0,0,33,0,0,0,67,"2,5,8-trioxanonane",heptane,COCCOCCOC,CCCCCCC
+155,"1,2-dihydroxypropane__amylcarbinol",66,0,0,0,0,0,0,66,"1,2-dihydroxypropane",amylcarbinol,CC(O)CO,CCCCCCO
+158,"1,2-dihydroxypropane__methyl alcohol",66,0,0,0,0,0,0,66,"1,2-dihydroxypropane",methyl alcohol,CC(O)CO,CO
+162,"1,4-dimethylbenzene__heptane",66,0,0,0,0,0,0,66,"1,4-dimethylbenzene",heptane,Cc1ccc(C)cc1,CCCCCCC
+164,butylcyclohexane__JP-10,66,0,0,0,0,0,0,66,butylcyclohexane,JP-10,CCCCC1CCCCC1,C1CC2C3CCC(C3)C2C1
+166,"1,2-dihydroxypropane__1-nonanol",66,0,0,0,0,0,0,66,"1,2-dihydroxypropane",1-nonanol,CC(O)CO,CCCCCCCCCO
+167,"1,2,4-trimethylcyclohexane__JP-10",66,0,0,0,0,0,0,66,"1,2,4-trimethylcyclohexane",JP-10,CC1CCC(C)C(C)C1,C1CC2C3CCC(C3)C2C1
+168,methylcyclohexane__JP-10,66,0,0,0,0,0,0,66,methylcyclohexane,JP-10,CC1CCCCC1,C1CC2C3CCC(C3)C2C1
+169,ethylcyclohexane__JP-10,66,0,0,0,0,0,0,66,ethylcyclohexane,JP-10,CCC1CCCCC1,C1CC2C3CCC(C3)C2C1
+170,"1,2-dihydroxypropane__1-octanol",66,0,0,0,0,0,0,66,"1,2-dihydroxypropane",1-octanol,CC(O)CO,CCCCCCCCO
+262,toluene__hexane,39,0,11,0,16,0,0,66,toluene,hexane,Cc1ccccc1,CCCCCC
+173,"1,3,5-trimethylbenzene__octane",64,0,0,0,0,0,0,64,"1,3,5-trimethylbenzene",octane,Cc1cc(C)cc(C)c1,CCCCCCCC
+174,methanol__cyclohexane,64,0,0,0,0,0,0,64,methanol,cyclohexane,CO,C1CCCCC1
+175,"1,3-dimethylbenzene__octane",64,0,0,0,0,0,0,64,"1,3-dimethylbenzene",octane,Cc1cccc(C)c1,CCCCCCCC
+307,dimethylglycol__heptane,33,0,0,31,0,0,0,64,dimethylglycol,heptane,COCCOC,CCCCCCC
+311,3-methylphenol__1-nonanol,32,0,32,0,0,0,0,64,3-methylphenol,1-nonanol,Cc1cccc(O)c1,CCCCCCCCCO
+312,2-methylphenol__1-nonanol,32,0,32,0,0,0,0,64,2-methylphenol,1-nonanol,Cc1ccccc1O,CCCCCCCCCO
+313,methyl phenyl ether__1-nonanol,32,0,32,0,0,0,0,64,methyl phenyl ether,1-nonanol,COc1ccccc1,CCCCCCCCCO
+314,4-methylphenol__1-nonanol,32,0,32,0,0,0,0,64,4-methylphenol,1-nonanol,Cc1ccc(O)cc1,CCCCCCCCCO
+178,ethanol__2-methyl-2-propanol,63,0,0,0,0,0,0,63,ethanol,2-methyl-2-propanol,CCO,CC(C)(C)O
+180,2-phenylethanol__benzyl alcohol,63,0,0,0,0,0,0,63,2-phenylethanol,benzyl alcohol,OCCc1ccccc1,OCc1ccccc1
+181,"2,2,4-trimethylpentane__1,3-dioxolane",63,0,0,0,0,0,0,63,"2,2,4-trimethylpentane","1,3-dioxolane",CC(C)CC(C)(C)C,C1COCO1
+182,2-propanol__benzyl alcohol,63,0,0,0,0,0,0,63,2-propanol,benzyl alcohol,CC(C)O,OCc1ccccc1
+183,"2-methyl-2-propanol__2,2,4-trimethylpentane",63,0,0,0,0,0,0,63,2-methyl-2-propanol,"2,2,4-trimethylpentane",CC(C)(C)O,CC(C)CC(C)(C)C
+221,ethylbenzene__cyclooctane,48,0,13,0,0,0,0,61,ethylbenzene,cyclooctane,CCc1ccccc1,C1CCCCCCC1
+234,toluene__cyclooctane,48,0,13,0,0,0,0,61,toluene,cyclooctane,Cc1ccccc1,C1CCCCCCC1
+239,benzene__cyclooctane,48,0,13,0,0,0,0,61,benzene,cyclooctane,c1ccccc1,C1CCCCCCC1
+602,"(RS)-2-butanol__1,1-dimethylethyl methyl ether",0,0,0,0,61,0,0,61,(RS)-2-butanol,"1,1-dimethylethyl methyl ether",CCC(C)O,COC(C)(C)C
+187,"1,2-dihydroxypropane__n-propyl alcohol",60,0,0,0,0,0,0,60,"1,2-dihydroxypropane",n-propyl alcohol,CC(O)CO,CCCO
+188,ethanol__n-decane,60,0,0,0,0,0,0,60,ethanol,n-decane,CCO,CCCCCCCCCC
+319,"furfuryl alcohol, tetrahydro-__water",30,0,30,0,0,0,0,60,"furfuryl alcohol, tetrahydro-",water,OCC1CCCO1,O
+583,cyclohexane__tetrahydropyran,0,0,13,0,32,0,14,59,cyclohexane,tetrahydropyran,C1CCCCC1,C1CCOCC1
+603,"ethanol, 2-ethoxy-__octane",0,0,0,0,59,0,0,59,"ethanol, 2-ethoxy-",octane,CCOCCO,CCCCCCCC
+260,benzene__heptane,40,0,18,0,0,0,0,58,benzene,heptane,c1ccccc1,CCCCCCC
+604,"ethanol, 2-ethoxy-__cyclohexane",0,0,0,0,58,0,0,58,"ethanol, 2-ethoxy-",cyclohexane,CCOCCO,C1CCCCC1
+243,toluene__heptane,45,0,12,0,0,0,0,57,toluene,heptane,Cc1ccccc1,CCCCCCC
+605,1-butanol__5-oxanonane,0,0,0,0,57,0,0,57,1-butanol,5-oxanonane,CCCCO,CCCCOCCCC
+194,n-propanol__water,56,0,0,0,0,0,0,56,n-propanol,water,CCCO,O
+196,"1-hexanol__1,4-dioxane",56,0,0,0,0,0,0,56,1-hexanol,"1,4-dioxane",CCCCCCO,C1COCCO1
+198,"1,4-dimethylbenzene__pentylcarbinol",55,0,0,0,0,0,0,55,"1,4-dimethylbenzene",pentylcarbinol,Cc1ccc(C)cc1,CCCCCCO
+201,methanol__3-methylphenol,55,0,0,0,0,0,0,55,methanol,3-methylphenol,CO,Cc1cccc(O)c1
+202,2-propanol__1-propanol,55,0,0,0,0,0,0,55,2-propanol,1-propanol,CC(C)O,CCCO
+204,1-octanol__heptane,55,0,0,0,0,0,0,55,1-octanol,heptane,CCCCCCCCO,CCCCCCC
+206,cyclohexane__JP-10,55,0,0,0,0,0,0,55,cyclohexane,JP-10,C1CCCCC1,C1CC2C3CCC(C3)C2C1
+207,methanol__4-methylphenol,55,0,0,0,0,0,0,55,methanol,4-methylphenol,CO,Cc1ccc(O)cc1
+208,"pentyl alcohol__1,2-dimethoxyethane",54,0,0,0,0,0,0,54,pentyl alcohol,"1,2-dimethoxyethane",CCCCCO,COCCOC
+324,"1,3-dimethylbenzene__cyclooctane",27,0,27,0,0,0,0,54,"1,3-dimethylbenzene",cyclooctane,Cc1cccc(C)c1,C1CCCCCCC1
+310,1-propanol__isopropyl ether,32,0,21,0,0,0,0,53,1-propanol,isopropyl ether,CCCO,CC(C)OC(C)C
+325,"1,2-dimethylbenzene__methylcyclohexane",26,0,26,0,0,0,0,52,"1,2-dimethylbenzene",methylcyclohexane,Cc1ccccc1C,CC1CCCCC1
+326,"1,3-dimethylbenzene__methylcyclohexane",26,0,26,0,0,0,0,52,"1,3-dimethylbenzene",methylcyclohexane,Cc1cccc(C)c1,CC1CCCCC1
+327,"1,4-dimethylbenzene__cyclopentane",26,0,26,0,0,0,0,52,"1,4-dimethylbenzene",cyclopentane,Cc1ccc(C)cc1,C1CCCC1
+328,"1,2-dimethylbenzene__cyclohexane",26,0,26,0,0,0,0,52,"1,2-dimethylbenzene",cyclohexane,Cc1ccccc1C,C1CCCCC1
+329,"1,3-dimethylbenzene__cyclopentane",26,0,26,0,0,0,0,52,"1,3-dimethylbenzene",cyclopentane,Cc1cccc(C)c1,C1CCCC1
+330,"1,2-dimethylbenzene__cyclooctane",26,0,26,0,0,0,0,52,"1,2-dimethylbenzene",cyclooctane,Cc1ccccc1C,C1CCCCCCC1
+331,"1,3,5-trimethylbenzene__cyclopentane",26,0,26,0,0,0,0,52,"1,3,5-trimethylbenzene",cyclopentane,Cc1cc(C)cc(C)c1,C1CCCC1
+332,"1,3,5-trimethylbenzene__cyclohexane",26,0,26,0,0,0,0,52,"1,3,5-trimethylbenzene",cyclohexane,Cc1cc(C)cc(C)c1,C1CCCCC1
+334,"1,3,5-trimethylbenzene__cyclooctane",26,0,26,0,0,0,0,52,"1,3,5-trimethylbenzene",cyclooctane,Cc1cc(C)cc(C)c1,C1CCCCCCC1
+336,"1,3-dimethylbenzene__cyclohexane",26,0,26,0,0,0,0,52,"1,3-dimethylbenzene",cyclohexane,Cc1cccc(C)c1,C1CCCCC1
+337,"1,4-dimethylbenzene__cyclooctane",26,0,26,0,0,0,0,52,"1,4-dimethylbenzene",cyclooctane,Cc1ccc(C)cc1,C1CCCCCCC1
+338,"1,2-dimethylbenzene__cyclopentane",26,0,26,0,0,0,0,52,"1,2-dimethylbenzene",cyclopentane,Cc1ccccc1C,C1CCCC1
+568,"cyclohexane__1,4-dioxane",0,0,33,0,19,0,0,52,cyclohexane,"1,4-dioxane",C1CCCCC1,C1COCCO1
+606,"hexane__ethanol, 2-ethoxy-",0,0,0,0,51,0,0,51,hexane,"ethanol, 2-ethoxy-",CCCCCC,CCOCCO
+607,1-pentanol__cyclohexane,0,0,0,0,51,0,0,51,1-pentanol,cyclohexane,CCCCCO,C1CCCCC1
+210,"1,2-ethanediol__1-hexanol",50,0,0,0,0,0,0,50,"1,2-ethanediol",1-hexanol,OCCO,CCCCCCO
+211,"1-butanol__1,2-ethanediol",50,0,0,0,0,0,0,50,1-butanol,"1,2-ethanediol",CCCCO,OCCO
+212,"1,2-ethanediol__1-octanol",50,0,0,0,0,0,0,50,"1,2-ethanediol",1-octanol,OCCO,CCCCCCCCO
+219,bis(2-hydroxyethyl) ether__butylmethylcarbinol,48,0,0,0,0,0,0,48,bis(2-hydroxyethyl) ether,butylmethylcarbinol,OCCOCCO,CCCCC(C)O
+220,"benzene__butane, 2-methoxy-2-methyl-",48,0,0,0,0,0,0,48,benzene,"butane, 2-methoxy-2-methyl-",c1ccccc1,CCC(C)(C)OC
+222,sec-propyl alcohol__bis(2-hydroxyethyl) ether,48,0,0,0,0,0,0,48,sec-propyl alcohol,bis(2-hydroxyethyl) ether,CC(C)O,OCCOCCO
+227,"2,2,4-trimethylpentane__butane, 2-methoxy-2-methyl-",48,0,0,0,0,0,0,48,"2,2,4-trimethylpentane","butane, 2-methoxy-2-methyl-",CC(C)CC(C)(C)C,CCC(C)(C)OC
+231,butan-2-ol__bis(2-hydroxyethyl) ether,48,0,0,0,0,0,0,48,butan-2-ol,bis(2-hydroxyethyl) ether,CCC(C)O,OCCOCCO
+237,bis(2-hydroxyethyl) ether__amylmethylcarbinol,48,0,0,0,0,0,0,48,bis(2-hydroxyethyl) ether,amylmethylcarbinol,OCCOCCO,CCCCCCCO
+238,bis(2-hydroxyethyl) ether__pentan-2-ol,48,0,0,0,0,0,0,48,bis(2-hydroxyethyl) ether,pentan-2-ol,OCCOCCO,CCCC(C)O
+283,methylcyclohexane__1-heptanol,36,0,12,0,0,0,0,48,methylcyclohexane,1-heptanol,CC1CCCCC1,CCCCCCCO
+286,benzene__nonane,35,0,13,0,0,0,0,48,benzene,nonane,c1ccccc1,CCCCCCCCC
+344,2-hydroxymethylfuran__water,24,0,24,0,0,0,0,48,2-hydroxymethylfuran,water,OCc1occc1,O
+287,ethylbenzene__heptane,34,0,12,0,0,0,0,46,ethylbenzene,heptane,CCc1ccccc1,CCCCCCC
+240,1-hexanol__heptane,45,0,0,0,0,0,0,45,1-hexanol,heptane,CCCCCCO,CCCCCCC
+242,isopropanol__isobutyl alcohol,45,0,0,0,0,0,0,45,isopropanol,isobutyl alcohol,CC(C)O,CC(C)CO
+244,"ethanol__1,2-dimethoxyethane",45,0,0,0,0,0,0,45,ethanol,"1,2-dimethoxyethane",CCO,COCCOC
+597,pentan-1-ol__n-octane,0,0,0,45,0,0,0,45,pentan-1-ol,n-octane,CCCCCO,CCCCCCCC
+598,n-octane__butyl oxide,0,0,0,45,0,0,0,45,n-octane,butyl oxide,CCCCCCCC,CCCCOCCCC
+599,pentan-1-ol__butyl oxide,0,0,0,45,0,0,0,45,pentan-1-ol,butyl oxide,CCCCCO,CCCCOCCCC
+247,"1,2-dimethoxyethane__1-octanol",44,0,0,0,0,0,0,44,"1,2-dimethoxyethane",1-octanol,COCCOC,CCCCCCCCO
+248,n-propyl alcohol__isobutyl alcohol,44,0,0,0,0,0,0,44,n-propyl alcohol,isobutyl alcohol,CCCO,CC(C)CO
+290,"2-butoxyethanol__1-butanol, 3-methyl-",33,0,11,0,0,0,0,44,2-butoxyethanol,"1-butanol, 3-methyl-",CCCCOCCO,CC(C)CCO
+291,1-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,1-propanol,methylcyclohexane,CCCO,CC1CCCCC1
+292,1-butanol__methoxybenzene,33,0,11,0,0,0,0,44,1-butanol,methoxybenzene,CCCCO,COc1ccccc1
+294,methoxybenzene__methylcyclohexane,33,0,11,0,0,0,0,44,methoxybenzene,methylcyclohexane,COc1ccccc1,CC1CCCCC1
+295,1-pentanol__methoxybenzene,33,0,11,0,0,0,0,44,1-pentanol,methoxybenzene,CCCCCO,COc1ccccc1
+296,2-methyl-1-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,2-methyl-1-propanol,methylcyclohexane,CC(C)CO,CC1CCCCC1
+297,methylcyclohexane__3-methyl-1-butanol,33,0,11,0,0,0,0,44,methylcyclohexane,3-methyl-1-butanol,CC1CCCCC1,CC(C)CCO
+298,2-propanol__methoxybenzene,33,0,11,0,0,0,0,44,2-propanol,methoxybenzene,CC(C)O,COc1ccccc1
+299,2-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,2-propanol,methylcyclohexane,CC(C)O,CC1CCCCC1
+300,1-propanol__methoxybenzene,33,0,11,0,0,0,0,44,1-propanol,methoxybenzene,CCCO,COc1ccccc1
+301,ethanol__methoxybenzene,33,0,11,0,0,0,0,44,ethanol,methoxybenzene,CCO,COc1ccccc1
+306,methoxybenzene__3-methyl-1-butanol,33,0,11,0,0,0,0,44,methoxybenzene,3-methyl-1-butanol,COc1ccccc1,CC(C)CCO
+346,ethanol__isopropyl ether,24,0,0,0,19,0,0,43,ethanol,isopropyl ether,CCO,CC(C)OC(C)C
+249,"1,3,5-trimethylbenzene__2-methoxyethanol",42,0,0,0,0,0,0,42,"1,3,5-trimethylbenzene",2-methoxyethanol,Cc1cc(C)cc(C)c1,COCCO
+250,"1,4-dimethylbenzene__hexane",42,0,0,0,0,0,0,42,"1,4-dimethylbenzene",hexane,Cc1ccc(C)cc1,CCCCCC
+251,"1,3,5-trimethylbenzene__1,2-dimethoxyethane",42,0,0,0,0,0,0,42,"1,3,5-trimethylbenzene","1,2-dimethoxyethane",Cc1cc(C)cc(C)c1,COCCOC
+253,"1,2,4-trimethylbenzene__1,2-dimethoxyethane",42,0,0,0,0,0,0,42,"1,2,4-trimethylbenzene","1,2-dimethoxyethane",CC1=CC(=C(C)C=C1)C,COCCOC
+254,"1,2,4-trimethylbenzene__2-methoxyethanol",42,0,0,0,0,0,0,42,"1,2,4-trimethylbenzene",2-methoxyethanol,CC1=CC(=C(C)C=C1)C,COCCO
+256,toluene__1-octanol,42,0,0,0,0,0,0,42,toluene,1-octanol,Cc1ccccc1,CCCCCCCCO
+258,toluene__1-heptanol,42,0,0,0,0,0,0,42,toluene,1-heptanol,Cc1ccccc1,CCCCCCCO
+371,ethylene glycol methyl ether__water,21,0,21,0,0,0,0,42,ethylene glycol methyl ether,water,COCCO,O
+372,1-propanol__tert-amyl methyl ether,21,0,21,0,0,0,0,42,1-propanol,tert-amyl methyl ether,CCCO,CCC(C)(C)OC
+373,1-propanol__methyl tert-butyl ether,21,0,21,0,0,0,0,42,1-propanol,methyl tert-butyl ether,CCCO,COC(C)(C)C
+408,"isopropyl ether__2,2,4-trimethylpentane",13,0,10,0,19,0,0,42,isopropyl ether,"2,2,4-trimethylpentane",CC(C)OC(C)C,CC(C)CC(C)(C)C
+577,"1,2-dimethylbenzene__tetrahydropyran",0,0,14,0,14,0,14,42,"1,2-dimethylbenzene",tetrahydropyran,Cc1ccccc1C,C1CCOCC1
+578,n-hexane__tetrahydropyran,0,0,14,0,14,0,14,42,n-hexane,tetrahydropyran,CCCCCC,C1CCOCC1
+579,"1,3-dimethylbenzene__tetrahydropyran",0,0,14,0,14,0,14,42,"1,3-dimethylbenzene",tetrahydropyran,Cc1cccc(C)c1,C1CCOCC1
+580,tetrahydropyran__heptane,0,0,14,0,14,0,14,42,tetrahydropyran,heptane,C1CCOCC1,CCCCCCC
+581,"1,4-dimethylbenzene__tetrahydropyran",0,0,14,0,14,0,14,42,"1,4-dimethylbenzene",tetrahydropyran,Cc1ccc(C)cc1,C1CCOCC1
+608,n-heptane__2-pentanol,0,0,0,0,42,0,0,42,n-heptane,2-pentanol,CCCCCCC,CCCC(C)O
+609,pentan-1-ol__isooctane,0,0,0,0,42,0,0,42,pentan-1-ol,isooctane,CCCCCO,CCCCCC(C)C
+610,1-pentanol__toluene,0,0,0,0,42,0,0,42,1-pentanol,toluene,CCCCCO,Cc1ccccc1
+611,pentan-1-ol__heptane,0,0,0,0,42,0,0,42,pentan-1-ol,heptane,CCCCCO,CCCCCCC
+612,"2,2,4-trimethylpentane__2-pentanol",0,0,0,0,42,0,0,42,"2,2,4-trimethylpentane",2-pentanol,CC(C)CC(C)(C)C,CCCC(C)O
+259,xyliton__water,40,0,0,0,0,0,0,40,xyliton,water,OC[C@H](O)C(O)[C@H](O)CO,O
+349,"3,6-dioxa-1-octanol__water",24,0,16,0,0,0,0,40,"3,6-dioxa-1-octanol",water,CCOCCOCCO,O
+270,cyclohexane__2-pentanol,39,0,0,0,0,0,0,39,cyclohexane,2-pentanol,C1CCCCC1,CCCC(C)O
+613,"2-methyl-2-butanol__1,1-dimethylethyl methyl ether",0,0,0,0,39,0,0,39,2-methyl-2-butanol,"1,1-dimethylethyl methyl ether",CCC(C)(C)O,COC(C)(C)C
+377,1-propanol__2-methyl-1-butanol,19,0,19,0,0,0,0,38,1-propanol,2-methyl-1-butanol,CCCO,CCC(C)CO
+378,1-propanol__3-methyl-1-butanol,19,0,19,0,0,0,0,38,1-propanol,3-methyl-1-butanol,CCCO,CC(C)CCO
+379,methanol__2-methyl-1-butanol,19,0,19,0,0,0,0,38,methanol,2-methyl-1-butanol,CO,CCC(C)CO
+383,"hexane__ether, methyl tert-pentyl",19,0,0,0,0,0,19,38,hexane,"ether, methyl tert-pentyl",CCCCCC,CCC(C)(C)OC
+614,"5-oxanonane__2,2,4-trimethylpentane",0,0,0,0,38,0,0,38,5-oxanonane,"2,2,4-trimethylpentane",CCCCOCCCC,CC(C)CC(C)(C)C
+615,heptane__dibutyl ether,0,0,0,0,38,0,0,38,heptane,dibutyl ether,CCCCCCC,CCCCOCCCC
+616,methylcyclohexane__5-oxanonane,0,0,0,0,38,0,0,38,methylcyclohexane,5-oxanonane,CC1CCCCC1,CCCCOCCCC
+617,toluene__5-oxanonane,0,0,0,0,38,0,0,38,toluene,5-oxanonane,Cc1ccccc1,CCCCOCCCC
+350,ethylbenzene__hexane,24,0,13,0,0,0,0,37,ethylbenzene,hexane,CCc1ccccc1,CCCCCC
+285,"1,2-dimethylbenzene__1,2-dimethoxyethane",36,0,0,0,0,0,0,36,"1,2-dimethylbenzene","1,2-dimethoxyethane",Cc1ccccc1C,COCCOC
+335,1-pentanol__cyclopentane,26,0,0,0,10,0,0,36,1-pentanol,cyclopentane,CCCCCO,C1CCCC1
+386,water__dipropylene glycol monomethyl ether,18,0,18,0,0,0,0,36,water,dipropylene glycol monomethyl ether,O,COC(C)COC(C)CO
+387,2-isopropoxyethanol__water,18,0,18,0,0,0,0,36,2-isopropoxyethanol,water,CC(C)OCCO,O
+618,"benzene__ethanol, 2-ethoxy-",0,0,0,0,36,0,0,36,benzene,"ethanol, 2-ethoxy-",c1ccccc1,CCOCCO
+342,1-heptanol__cyclopentane,24,0,0,0,11,0,0,35,1-heptanol,cyclopentane,CCCCCCCO,C1CCCC1
+351,toluene__nonane,23,0,12,0,0,0,0,35,toluene,nonane,Cc1ccccc1,CCCCCCCCC
+619,ethanol__benzene,0,0,0,0,35,0,0,35,ethanol,benzene,CCO,c1ccccc1
+289,"methoxybenzene__1,4-dioxane",33,0,0,0,0,0,0,33,methoxybenzene,"1,4-dioxane",COc1ccccc1,C1COCCO1
+293,"1,2-propanediol__1,2-ethanediol",33,0,0,0,0,0,0,33,"1,2-propanediol","1,2-ethanediol",CC(O)CO,OCCO
+302,"1,2-propanediol__1,3-propanediol",33,0,0,0,0,0,0,33,"1,2-propanediol","1,3-propanediol",CC(O)CO,OCCCO
+303,"1,4-dimethylbenzene__1,2-dimethoxyethane",33,0,0,0,0,0,0,33,"1,4-dimethylbenzene","1,2-dimethoxyethane",Cc1ccc(C)cc1,COCCOC
+304,methylcyclohexane__exo-tetrahydrodicyclopentadiene,33,0,0,0,0,0,0,33,methylcyclohexane,exo-tetrahydrodicyclopentadiene,CC1CCCCC1,C1CC2C3CCC(C3)C2C1
+308,"1,2-propanediol__pentylcarbinol",33,0,0,0,0,0,0,33,"1,2-propanediol",pentylcarbinol,CC(O)CO,CCCCCCO
+309,"1,2-ethanediol__1,3-propanediol",33,0,0,0,0,0,0,33,"1,2-ethanediol","1,3-propanediol",OCCO,OCCCO
+567,"1,4-dioxane__cyclopentane",0,0,33,0,0,0,0,33,"1,4-dioxane",cyclopentane,C1COCCO1,C1CCCC1
+569,"benzene__1,4-dioxane",0,0,33,0,0,0,0,33,benzene,"1,4-dioxane",c1ccccc1,C1COCCO1
+389,2-methyl-1-propanol__hexane,16,0,16,0,0,0,0,32,2-methyl-1-propanol,hexane,CC(C)CO,CCCCCC
+390,2-methyl-1-propanol__decane,16,0,16,0,0,0,0,32,2-methyl-1-propanol,decane,CC(C)CO,CCCCCCCCCC
+391,2-methyl-1-propanol__octane,16,0,16,0,0,0,0,32,2-methyl-1-propanol,octane,CC(C)CO,CCCCCCCC
+315,"1,3-dimethylbenzene__hexane",31,0,0,0,0,0,0,31,"1,3-dimethylbenzene",hexane,Cc1cccc(C)c1,CCCCCC
+316,xylitol__water,30,0,0,0,0,0,0,30,xylitol,water,OC[C@@H](O)[C@H](O)[C@@H](O)CO,O
+317,propan-1-ol__water,30,0,0,0,0,0,0,30,propan-1-ol,water,CCCO,O
+318,"1,2-propanediol__1-heptanol",30,0,0,0,0,0,0,30,"1,2-propanediol",1-heptanol,CC(O)CO,CCCCCCCO
+399,2-phenylethanol__ethoxybenzene,13,0,0,0,17,0,0,30,2-phenylethanol,ethoxybenzene,OCCc1ccccc1,CCOc1ccccc1
+570,benzyl alcohol__1-octanol,0,0,30,0,0,0,0,30,benzyl alcohol,1-octanol,OCc1ccccc1,CCCCCCCCO
+571,benzyl alcohol__1-heptanol,0,0,30,0,0,0,0,30,benzyl alcohol,1-heptanol,OCc1ccccc1,CCCCCCCO
+572,benzyl alcohol__1-nonanol,0,0,30,0,0,0,0,30,benzyl alcohol,1-nonanol,OCc1ccccc1,CCCCCCCCCO
+620,benzene__5-oxanonane,0,0,0,0,30,0,0,30,benzene,5-oxanonane,c1ccccc1,CCCCOCCCC
+412,benzyl alcohol__ethoxybenzene,12,0,0,0,17,0,0,29,benzyl alcohol,ethoxybenzene,OCc1ccccc1,CCOc1ccccc1
+417,benzyl alcohol__methoxybenzene,12,0,0,0,17,0,0,29,benzyl alcohol,methoxybenzene,OCc1ccccc1,COc1ccccc1
+419,2-phenylethanol__methoxybenzene,12,0,0,0,17,0,0,29,2-phenylethanol,methoxybenzene,OCCc1ccccc1,COc1ccccc1
+420,ethoxybenzene__3-phenyl-1-propanol,12,0,0,0,17,0,0,29,ethoxybenzene,3-phenyl-1-propanol,CCOc1ccccc1,OCCCc1ccccc1
+422,methoxybenzene__3-phenyl-1-propanol,12,0,0,0,17,0,0,29,methoxybenzene,3-phenyl-1-propanol,COc1ccccc1,OCCCc1ccccc1
+393,"1,2-butanediol__water",14,0,0,0,0,0,14,28,"1,2-butanediol",water,CCC(O)CO,O
+394,trimethylene glycol__water,14,0,0,0,0,0,14,28,trimethylene glycol,water,OCCCO,O
+395,"2,3-butanediol__water",14,0,0,0,0,0,14,28,"2,3-butanediol",water,CC(O)C(C)O,O
+396,"butane, 1,4-dihydroxy-__water",14,0,0,0,0,0,14,28,"butane, 1,4-dihydroxy-",water,OCCCCO,O
+397,"1,3-butanediol__water",14,0,0,0,0,0,14,28,"1,3-butanediol",water,CC(O)CCO,O
+418,"ethanol, 2-ethoxy-__water",12,0,16,0,0,0,0,28,"ethanol, 2-ethoxy-",water,CCOCCO,O
+440,"1,4-dioxane__water",10,0,18,0,0,0,0,28,"1,4-dioxane",water,C1COCCO1,O
+321,tetrole__n-hexane,27,0,0,0,0,0,0,27,tetrole,n-hexane,o1cccc1,CCCCCC
+322,"1,2-dimethylbenzene__hexane",27,0,0,0,0,0,0,27,"1,2-dimethylbenzene",hexane,Cc1ccccc1C,CCCCCC
+323,phenylmethane__tetrole,27,0,0,0,0,0,0,27,phenylmethane,tetrole,Cc1ccccc1,o1cccc1
+573,"benzene__1,3-dioxolane",0,0,27,0,0,0,0,27,benzene,"1,3-dioxolane",c1ccccc1,C1COCO1
+574,"cyclopentane__1,3-dioxolane",0,0,27,0,0,0,0,27,cyclopentane,"1,3-dioxolane",C1CCCC1,C1COCO1
+575,"cyclohexane__1,3-dioxolane",0,0,27,0,0,0,0,27,cyclohexane,"1,3-dioxolane",C1CCCCC1,C1COCO1
+400,ethylbenzene__octane,13,0,13,0,0,0,0,26,ethylbenzene,octane,CCc1ccccc1,CCCCCCCC
+403,toluene__cyclopentane,13,0,13,0,0,0,0,26,toluene,cyclopentane,Cc1ccccc1,C1CCCC1
+406,ethylbenzene__cyclopentane,13,0,13,0,0,0,0,26,ethylbenzene,cyclopentane,CCc1ccccc1,C1CCCC1
+407,ethylbenzene__nonane,13,0,13,0,0,0,0,26,ethylbenzene,nonane,CCc1ccccc1,CCCCCCCCC
+410,benzene__cyclopentane,13,0,13,0,0,0,0,26,benzene,cyclopentane,c1ccccc1,C1CCCC1
+339,n-propyl alcohol__water,25,0,0,0,0,0,0,25,n-propyl alcohol,water,CCCO,O
+340,"propan-1-ol__1,3-benzenediol",25,0,0,0,0,0,0,25,propan-1-ol,"1,3-benzenediol",CCCO,Oc1cccc(O)c1
+341,"butan-1-ol__1,3-benzenediol",25,0,0,0,0,0,0,25,butan-1-ol,"1,3-benzenediol",CCCCO,Oc1cccc(O)c1
+374,glycerol__ethanol,20,5,0,0,0,0,0,25,glycerol,ethanol,OCC(O)CO,CCO
+404,ethylene glycol__1-heptanol,13,0,12,0,0,0,0,25,ethylene glycol,1-heptanol,OCCO,CCCCCCCO
+343,methanol__toluene,24,0,0,0,0,0,0,24,methanol,toluene,CO,Cc1ccccc1
+345,2-ethoxyethanol__water,24,0,0,0,0,0,0,24,2-ethoxyethanol,water,CCOCCO,O
+347,2-n-butoxyethanol__water,24,0,0,0,0,0,0,24,2-n-butoxyethanol,water,CCCCOCCO,O
+348,D-(+)-arabitol__water,24,0,0,0,0,0,0,24,D-(+)-arabitol,water,OCC(O)C(O)C(O)CO,O
+413,isobutanol__water,12,0,12,0,0,0,0,24,isobutanol,water,CC(C)CO,O
+414,benzene__hexane,12,0,12,0,0,0,0,24,benzene,hexane,c1ccccc1,CCCCCC
+424,"ethane, 1,1'-oxybis-__1,3-dioxolane",11,0,12,0,0,0,0,23,"ethane, 1,1'-oxybis-","1,3-dioxolane",CCOCC,C1COCO1
+621,neohexane__tetrahydrofuran,0,0,0,0,23,0,0,23,neohexane,tetrahydrofuran,CCC(C)(C)C,C1CCOC1
+622,diisopropyl__tetrahydrofuran,0,0,0,0,23,0,0,23,diisopropyl,tetrahydrofuran,CC(C)C(C)C,C1CCOC1
+352,ethylene glycol__1-nonanol,22,0,0,0,0,0,0,22,ethylene glycol,1-nonanol,OCCO,CCCCCCCCCO
+353,benzene__methoxybenzene,22,0,0,0,0,0,0,22,benzene,methoxybenzene,c1ccccc1,COc1ccccc1
+355,methoxybenzene__butylbenzene,22,0,0,0,0,0,0,22,methoxybenzene,butylbenzene,COc1ccccc1,CCCCc1ccccc1
+356,benzene__toluene,22,0,0,0,0,0,0,22,benzene,toluene,c1ccccc1,Cc1ccccc1
+357,"1,3-dimethylbenzene__pentylcarbinol",22,0,0,0,0,0,0,22,"1,3-dimethylbenzene",pentylcarbinol,Cc1cccc(C)c1,CCCCCCO
+358,methoxybenzene__toluene,22,0,0,0,0,0,0,22,methoxybenzene,toluene,COc1ccccc1,Cc1ccccc1
+359,benzene__ethylbenzene,22,0,0,0,0,0,0,22,benzene,ethylbenzene,c1ccccc1,CCc1ccccc1
+361,ethylbenzene__methoxybenzene,22,0,0,0,0,0,0,22,ethylbenzene,methoxybenzene,CCc1ccccc1,COc1ccccc1
+362,1-propanol__1-heptanol,22,0,0,0,0,0,0,22,1-propanol,1-heptanol,CCCO,CCCCCCCO
+363,"1,2-dimethylbenzene__pentylcarbinol",22,0,0,0,0,0,0,22,"1,2-dimethylbenzene",pentylcarbinol,Cc1ccccc1C,CCCCCCO
+364,methoxybenzene__propylbenzene,22,0,0,0,0,0,0,22,methoxybenzene,propylbenzene,COc1ccccc1,CCCc1ccccc1
+365,1-heptanol__1-nonanol,22,0,0,0,0,0,0,22,1-heptanol,1-nonanol,CCCCCCCO,CCCCCCCCCO
+366,ethylbenzene__toluene,22,0,0,0,0,0,0,22,ethylbenzene,toluene,CCc1ccccc1,Cc1ccccc1
+367,1-propanol__1-pentanol,22,0,0,0,0,0,0,22,1-propanol,1-pentanol,CCCO,CCCCCO
+368,1-propanol__1-nonanol,22,0,0,0,0,0,0,22,1-propanol,1-nonanol,CCCO,CCCCCCCCCO
+369,1-pentanol__1-nonanol,22,0,0,0,0,0,0,22,1-pentanol,1-nonanol,CCCCCO,CCCCCCCCCO
+370,1-pentanol__1-heptanol,22,0,0,0,0,0,0,22,1-pentanol,1-heptanol,CCCCCO,CCCCCCCO
+416,2-ethyl-1-hexanol__ethylene glycol,12,0,10,0,0,0,0,22,2-ethyl-1-hexanol,ethylene glycol,CCCCC(CC)CO,OCCO
+425,"ethane, 1,1'-oxybis-__pentan-1-ol",11,0,11,0,0,0,0,22,"ethane, 1,1'-oxybis-",pentan-1-ol,CCOCC,CCCCCO
+426,"2-methoxyethanol__1,3-dioxolane",11,0,11,0,0,0,0,22,2-methoxyethanol,"1,3-dioxolane",COCCO,C1COCO1
+431,"pentan-1-ol__1,3-dioxolane",11,0,11,0,0,0,0,22,pentan-1-ol,"1,3-dioxolane",CCCCCO,C1COCO1
+432,"ethanol, 2-ethoxy-__1,3-dioxolane",11,0,11,0,0,0,0,22,"ethanol, 2-ethoxy-","1,3-dioxolane",CCOCCO,C1COCO1
+433,"2-butoxyethanol__1,3-dioxolane",11,0,11,0,0,0,0,22,2-butoxyethanol,"1,3-dioxolane",CCCCOCCO,C1COCO1
+584,benzene__2-methyltetrahydrofuran,0,0,11,0,11,0,0,22,benzene,2-methyltetrahydrofuran,c1ccccc1,CC1CCCO1
+434,isopropyl ether__toluene,11,0,0,0,10,0,0,21,isopropyl ether,toluene,CC(C)OC(C)C,Cc1ccccc1
+623,tetramethylene oxide__dibutyl ether,0,0,0,0,21,0,0,21,tetramethylene oxide,dibutyl ether,C1CCOC1,CCCCOCCCC
+375,"ethanol__1,3-benzenediol",20,0,0,0,0,0,0,20,ethanol,"1,3-benzenediol",CCO,Oc1cccc(O)c1
+438,ethanol__ethylene glycol,10,0,10,0,0,0,0,20,ethanol,ethylene glycol,CCO,OCCO
+624,"2,3-dimethylbutane__ether, dipropyl",0,0,0,0,20,0,0,20,"2,3-dimethylbutane","ether, dipropyl",CC(C)C(C)C,CCCOCCC
+625,"butane, 2,2-dimethyl-__butyl oxide",0,0,0,0,20,0,0,20,"butane, 2,2-dimethyl-",butyl oxide,CCC(C)(C)C,CCCCOCCCC
+626,dipropyl ether__dibutyl ether,0,0,0,0,20,0,0,20,dipropyl ether,dibutyl ether,CCCOCCC,CCCCOCCCC
+627,tetramethylene oxide__dipropyl ether,0,0,0,0,20,0,0,20,tetramethylene oxide,dipropyl ether,C1CCOC1,CCCOCCC
+628,"2,3-dimethylbutane__butyl oxide",0,0,0,0,20,0,0,20,"2,3-dimethylbutane",butyl oxide,CC(C)C(C)C,CCCCOCCCC
+629,methanol__dibutyl ether,0,0,0,0,20,0,0,20,methanol,dibutyl ether,CO,CCCCOCCCC
+376,2-methyl-1-propanol__2-methyl-1-butanol,19,0,0,0,0,0,0,19,2-methyl-1-propanol,2-methyl-1-butanol,CC(C)CO,CCC(C)CO
+380,2-methyl-1-propanol__3-methyl-1-butanol,19,0,0,0,0,0,0,19,2-methyl-1-propanol,3-methyl-1-butanol,CC(C)CO,CC(C)CCO
+381,1-propanol__tert-butyl ethyl ether,19,0,0,0,0,0,0,19,1-propanol,tert-butyl ethyl ether,CCCO,CCOC(C)(C)C
+382,1-pentanol__2-methyl-1-propanol,19,0,0,0,0,0,0,19,1-pentanol,2-methyl-1-propanol,CCCCCO,CC(C)CO
+630,1-methoxy-2-propanol__cyclohexane,0,0,0,0,19,0,0,19,1-methoxy-2-propanol,cyclohexane,COCC(C)O,C1CCCCC1
+631,"butane, 2,2-dimethyl-__ether, dipropyl",0,0,0,0,19,0,0,19,"butane, 2,2-dimethyl-","ether, dipropyl",CCC(C)(C)C,CCCOCCC
+632,cyclohexane__2-butoxyethanol,0,0,0,0,19,0,0,19,cyclohexane,2-butoxyethanol,C1CCCCC1,CCCCOCCO
+633,1-pentanol__decane,0,0,0,0,19,0,0,19,1-pentanol,decane,CCCCCO,CCCCCCCCCC
+634,methanol__methoxymethane,0,0,0,0,19,0,0,19,methanol,methoxymethane,CO,COC
+635,cyclohexane__5-oxanonane,0,0,0,0,19,0,0,19,cyclohexane,5-oxanonane,C1CCCCC1,CCCCOCCCC
+636,epoxypropane__2-methylpentane,0,0,0,0,19,0,0,19,epoxypropane,2-methylpentane,CC1CO1,CCCC(C)C
+637,1-propanol__methoxymethane,0,0,0,0,19,0,0,19,1-propanol,methoxymethane,CCCO,COC
+638,"octane__1,4-dioxane",0,0,0,0,19,0,0,19,octane,"1,4-dioxane",CCCCCCCC,C1COCCO1
+639,ethanol__methoxymethane,0,0,0,0,19,0,0,19,ethanol,methoxymethane,CCO,COC
+640,1-butanol__methoxymethane,0,0,0,0,19,0,0,19,1-butanol,methoxymethane,CCCCO,COC
+641,cyclohexane__dibutyl ether,0,0,0,0,19,0,0,19,cyclohexane,dibutyl ether,C1CCCCC1,CCCCOCCCC
+642,benzene__1-methoxy-2-propanol,0,0,0,0,19,0,0,19,benzene,1-methoxy-2-propanol,c1ccccc1,COCC(C)O
+643,benzene__2-butoxyethanol,0,0,0,0,19,0,0,19,benzene,2-butoxyethanol,c1ccccc1,CCCCOCCO
+644,ethanol__tetrahydropyran,0,0,0,0,19,0,0,19,ethanol,tetrahydropyran,CCO,C1CCOCC1
+384,ethane__toluene,18,0,0,0,0,0,0,18,ethane,toluene,CC,Cc1ccccc1
+385,"n-hexane__2,5-dimethylfuran",18,0,0,0,0,0,0,18,n-hexane,"2,5-dimethylfuran",CCCCCC,Cc1oc(C)cc1
+446,2-methyl-2-butanol__ethyl tert-pentyl ether,9,0,0,0,9,0,0,18,2-methyl-2-butanol,ethyl tert-pentyl ether,CCC(C)(C)O,CCOC(C)(C)CC
+448,butan-2-ol__ethyl tert-pentyl ether,9,0,0,0,9,0,0,18,butan-2-ol,ethyl tert-pentyl ether,CCC(C)O,CCOC(C)(C)CC
+450,1-butanol__ethyl tert-pentyl ether,9,0,0,0,9,0,0,18,1-butanol,ethyl tert-pentyl ether,CCCCO,CCOC(C)(C)CC
+646,1-pentanol__nonane,0,0,0,0,18,0,0,18,1-pentanol,nonane,CCCCCO,CCCCCCCCC
+647,1-pentanol__hexane,0,0,0,0,18,0,0,18,1-pentanol,hexane,CCCCCO,CCCCCC
+648,"benzyl alcohol__3,6-dioxa-1-octanol",0,0,0,0,17,0,0,17,benzyl alcohol,"3,6-dioxa-1-octanol",OCc1ccccc1,CCOCCOCCO
+649,benzyl alcohol__dibutyl ether,0,0,0,0,17,0,0,17,benzyl alcohol,dibutyl ether,OCc1ccccc1,CCCCOCCCC
+650,"benzyl alcohol__1,2-dimethoxyethane",0,0,0,0,17,0,0,17,benzyl alcohol,"1,2-dimethoxyethane",OCc1ccccc1,COCCOC
+651,"benzyl alcohol__ethanol, 2-ethoxy-",0,0,0,0,17,0,0,17,benzyl alcohol,"ethanol, 2-ethoxy-",OCc1ccccc1,CCOCCO
+652,1-propanol__decane,0,0,0,0,17,0,0,17,1-propanol,decane,CCCO,CCCCCCCCCC
+653,2-methyl-1-propanol__1-methyl-1-(1-methylethoxy)ethane,0,0,0,0,17,0,0,17,2-methyl-1-propanol,1-methyl-1-(1-methylethoxy)ethane,CC(C)CO,CC(C)OC(C)C
+654,"benzyl alcohol__3,6-dioxaoctane",0,0,0,0,17,0,0,17,benzyl alcohol,"3,6-dioxaoctane",OCc1ccccc1,CCOCCOCC
+388,methanol__dioxane,16,0,0,0,0,0,0,16,methanol,dioxane,CO,C1COCCO1
+466,tert-pentyl alcohol__water,0,16,0,0,0,0,0,16,tert-pentyl alcohol,water,CCC(C)(C)O,O
+576,2-methoxyethanol__water,0,0,16,0,0,0,0,16,2-methoxyethanol,water,COCCO,O
+655,1-propanol__heptane,0,0,0,0,16,0,0,16,1-propanol,heptane,CCCO,CCCCCCC
+467,"1-butanol, 3-methyl-__water",0,15,0,0,0,0,0,15,"1-butanol, 3-methyl-",water,CC(C)CCO,O
+468,2-methyl-1-butanol__water,0,15,0,0,0,0,0,15,2-methyl-1-butanol,water,CCC(C)CO,O
+656,ethanol__nonane,0,0,0,0,15,0,0,15,ethanol,nonane,CCO,CCCCCCCCC
+657,ethanol__decane,0,0,0,0,15,0,0,15,ethanol,decane,CCO,CCCCCCCCCC
+658,butan-2-ol__cyclohexyl alcohol,0,0,0,0,15,0,0,15,butan-2-ol,cyclohexyl alcohol,CCC(C)O,OC1CCCCC1
+659,1-propanol__nonane,0,0,0,0,15,0,0,15,1-propanol,nonane,CCCO,CCCCCCCCC
+660,"1,2-dimethylbenzene__dibutyl ether",0,0,0,0,15,0,0,15,"1,2-dimethylbenzene",dibutyl ether,Cc1ccccc1C,CCCCOCCCC
+398,2-ethyl-1-hexanol__1-nonanol,14,0,0,0,0,0,0,14,2-ethyl-1-hexanol,1-nonanol,CCCCC(CC)CO,CCCCCCCCCO
+661,benzene__2-methyl-1-propanol,0,0,0,0,14,0,0,14,benzene,2-methyl-1-propanol,c1ccccc1,CC(C)CO
+401,ethanol__oxane,13,0,0,0,0,0,0,13,ethanol,oxane,CCO,C1CCOCC1
+405,1-octanol__2-octanol,13,0,0,0,0,0,0,13,1-octanol,2-octanol,CCCCCCCCO,CCCCCCC(C)O
+409,anisole__phenol,13,0,0,0,0,0,0,13,anisole,phenol,COc1ccccc1,Oc1ccccc1
+411,2-ethyl-1-hexanol__1-heptanol,13,0,0,0,0,0,0,13,2-ethyl-1-hexanol,1-heptanol,CCCCC(CC)CO,CCCCCCCO
+469,pentan-2-ol__water,0,13,0,0,0,0,0,13,pentan-2-ol,water,CCCC(C)O,O
+582,"1-butanol__1,2-butanediol",0,0,13,0,0,0,0,13,1-butanol,"1,2-butanediol",CCCCO,CCC(O)CO
+662,1-butanol__1-methyl-1-(1-methylethoxy)ethane,0,0,0,0,13,0,0,13,1-butanol,1-methyl-1-(1-methylethoxy)ethane,CCCCO,CC(C)OC(C)C
+663,n-butyl alcohol__cyclohexyl alcohol,0,0,0,0,13,0,0,13,n-butyl alcohol,cyclohexyl alcohol,CCCCO,OC1CCCCC1
+415,"1,3-dioxolane__water",12,0,0,0,0,0,0,12,"1,3-dioxolane",water,C1COCO1,O
+421,2-propanol__methane,12,0,0,0,0,0,0,12,2-propanol,methane,CC(C)O,C
+423,methanol__tetrahydrofuran,12,0,0,0,0,0,0,12,methanol,tetrahydrofuran,CO,C1CCOC1
+664,1-methyl-1-(1-methylethoxy)ethane__heptane,0,0,0,0,12,0,0,12,1-methyl-1-(1-methylethoxy)ethane,heptane,CC(C)OC(C)C,CCCCCCC
+427,benzene__2-methoxyethanol,11,0,0,0,0,0,0,11,benzene,2-methoxyethanol,c1ccccc1,COCCO
+428,benzene__methyl tert-butyl ether,11,0,0,0,0,0,0,11,benzene,methyl tert-butyl ether,c1ccccc1,COC(C)(C)C
+429,benzene__dibutyl ether,11,0,0,0,0,0,0,11,benzene,dibutyl ether,c1ccccc1,CCCCOCCCC
+430,methanol__anisol,11,0,0,0,0,0,0,11,methanol,anisol,CO,COc1ccccc1
+435,toluene__2-methoxyethanol,11,0,0,0,0,0,0,11,toluene,2-methoxyethanol,Cc1ccccc1,COCCO
+436,p-xylene__2-methoxyethanol,11,0,0,0,0,0,0,11,p-xylene,2-methoxyethanol,Cc1ccc(C)cc1,COCCO
+437,ethanol__dibutyl ether,11,0,0,0,0,0,0,11,ethanol,dibutyl ether,CCO,CCCCOCCCC
+470,3-pentanol__water,0,11,0,0,0,0,0,11,3-pentanol,water,CCC(O)CC,O
+665,"1,2-propanediol__methanol",0,0,0,0,11,0,0,11,"1,2-propanediol",methanol,CC(O)CO,CO
+666,propyl alcohol__cyclohexyl alcohol,0,0,0,0,11,0,0,11,propyl alcohol,cyclohexyl alcohol,CCCO,OC1CCCCC1
+667,methanol__.alpha.-toluenol,0,0,0,0,11,0,0,11,methanol,.alpha.-toluenol,CO,OCc1ccccc1
+668,tetrahydrofuran__nonane,0,0,0,0,11,0,0,11,tetrahydrofuran,nonane,C1CCOC1,CCCCCCCCC
+669,1-hexanol__cyclopentane,0,0,0,0,11,0,0,11,1-hexanol,cyclopentane,CCCCCCO,C1CCCC1
+670,"isopropyl ether__1,3-dimethylbenzene",0,0,0,0,11,0,0,11,isopropyl ether,"1,3-dimethylbenzene",CC(C)OC(C)C,Cc1cccc(C)c1
+439,1-pentanol__2-ethyl-1-hexanol,10,0,0,0,0,0,0,10,1-pentanol,2-ethyl-1-hexanol,CCCCCO,CCCCC(CC)CO
+441,phenol__1-octanol,10,0,0,0,0,0,0,10,phenol,1-octanol,Oc1ccccc1,CCCCCCCCO
+442,"2-ethyl-1-hexanol__2,3-butanediol",10,0,0,0,0,0,0,10,2-ethyl-1-hexanol,"2,3-butanediol",CCCCC(CC)CO,CC(O)C(C)O
+443,2-propanol__ethane,10,0,0,0,0,0,0,10,2-propanol,ethane,CC(C)O,CC
+461,naphthalene__heptane,5,0,5,0,0,0,0,10,naphthalene,heptane,c1ccc2ccccc2c1,CCCCCCC
+462,naphthalene__cyclohexane,5,0,5,0,0,0,0,10,naphthalene,cyclohexane,c1ccc2ccccc2c1,C1CCCCC1
+471,3-methyl-2-butanol__water,0,10,0,0,0,0,0,10,3-methyl-2-butanol,water,CC(C)C(C)O,O
+585,isopropyl ether__hexane,0,0,10,0,0,0,0,10,isopropyl ether,hexane,CC(C)OC(C)C,CCCCCC
+586,isopropyl ether__heptane,0,0,10,0,0,0,0,10,isopropyl ether,heptane,CC(C)OC(C)C,CCCCCCC
+587,isopropyl ether__octane,0,0,10,0,0,0,0,10,isopropyl ether,octane,CC(C)OC(C)C,CCCCCCCC
+671,"1,2-propanediol__1-hexanol",0,0,0,0,10,0,0,10,"1,2-propanediol",1-hexanol,CC(O)CO,CCCCCCO
+672,pentan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,pentan-1-ol,tert-pentyl alcohol,CCCCCO,CCC(C)(C)O
+673,ethanol__cyclohexyl alcohol,0,0,0,0,10,0,0,10,ethanol,cyclohexyl alcohol,CCO,OC1CCCCC1
+674,ethanol__.alpha.-toluenol,0,0,0,0,10,0,0,10,ethanol,.alpha.-toluenol,CCO,OCc1ccccc1
+675,1-nonanol__cyclopentane,0,0,0,0,10,0,0,10,1-nonanol,cyclopentane,CCCCCCCCCO,C1CCCC1
+676,ethanol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,ethanol,tert-pentyl alcohol,CCO,CCC(C)(C)O
+677,butan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,butan-1-ol,tert-pentyl alcohol,CCCCO,CCC(C)(C)O
+678,"1,2-propanediol__1-pentanol",0,0,0,0,10,0,0,10,"1,2-propanediol",1-pentanol,CC(O)CO,CCCCCO
+679,"1,2-propanediol__ethanol",0,0,0,0,10,0,0,10,"1,2-propanediol",ethanol,CC(O)CO,CCO
+680,"1,2-propanediol__1-butanol",0,0,0,0,10,0,0,10,"1,2-propanediol",1-butanol,CC(O)CO,CCCCO
+681,1-octanol__cyclopentane,0,0,0,0,10,0,0,10,1-octanol,cyclopentane,CCCCCCCCO,C1CCCC1
+682,cyclohexane__1-heptanol,0,0,0,0,10,0,0,10,cyclohexane,1-heptanol,C1CCCCC1,CCCCCCCO
+683,propan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,propan-1-ol,tert-pentyl alcohol,CCCO,CCC(C)(C)O
+684,methanol__cyclohexyl alcohol,0,0,0,0,10,0,0,10,methanol,cyclohexyl alcohol,CO,OC1CCCCC1
+685,"1,2-propanediol__1-propanol",0,0,0,0,10,0,0,10,"1,2-propanediol",1-propanol,CC(O)CO,CCCO
+686,methanol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,methanol,tert-pentyl alcohol,CO,CCC(C)(C)O
+445,(RS)-2-butanol__water,9,0,0,0,0,0,0,9,(RS)-2-butanol,water,CCC(C)O,O
+447,"2-ethyl-1-hexanol__butane, 1,4-dihydroxy-",9,0,0,0,0,0,0,9,2-ethyl-1-hexanol,"butane, 1,4-dihydroxy-",CCCCC(CC)CO,OCCCCO
+449,cyclohexane__1-octanol,9,0,0,0,0,0,0,9,cyclohexane,1-octanol,C1CCCCC1,CCCCCCCCO
+451,isooctane__methyl tert-butyl ether,9,0,0,0,0,0,0,9,isooctane,methyl tert-butyl ether,CCCCCC(C)C,COC(C)(C)C
+472,furan__water,0,9,0,0,0,0,0,9,furan,water,o1cccc1,O
+588,isopropyl ether__cyclohexane,0,0,9,0,0,0,0,9,isopropyl ether,cyclohexane,CC(C)OC(C)C,C1CCCCC1
+589,isopropyl ether__tetralin,0,0,9,0,0,0,0,9,isopropyl ether,tetralin,CC(C)OC(C)C,C1CCc2ccccc2C1
+590,benzene__isopropyl ether,0,0,9,0,0,0,0,9,benzene,isopropyl ether,c1ccccc1,CC(C)OC(C)C
+591,decahydronaphthalene__isopropyl ether,0,0,9,0,0,0,0,9,decahydronaphthalene,isopropyl ether,C1CCC2CCCCC2C1,CC(C)OC(C)C
+687,propan-1-ol__.alpha.-toluenol,0,0,0,0,9,0,0,9,propan-1-ol,.alpha.-toluenol,CCCO,OCc1ccccc1
+688,1-pentanol__tetrahydropyran,0,0,0,0,9,0,0,9,1-pentanol,tetrahydropyran,CCCCCO,C1CCOCC1
+689,butan-1-ol__.alpha.-toluenol,0,0,0,0,9,0,0,9,butan-1-ol,.alpha.-toluenol,CCCCO,OCc1ccccc1
+690,tetrahydropyran__decane,0,0,0,0,9,0,0,9,tetrahydropyran,decane,C1CCOCC1,CCCCCCCCCC
+691,"1,4-dioxane__tetrahydropyran",0,0,0,0,9,0,0,9,"1,4-dioxane",tetrahydropyran,C1COCCO1,C1CCOCC1
+692,.alpha.-toluenol__pentylcarbinol,0,0,0,0,9,0,0,9,.alpha.-toluenol,pentylcarbinol,OCc1ccccc1,CCCCCCO
+693,cyclohexane__1-nonanol,0,0,0,0,9,0,0,9,cyclohexane,1-nonanol,C1CCCCC1,CCCCCCCCCO
+694,2-propanol__cyclohexyl alcohol,0,0,0,0,9,0,0,9,2-propanol,cyclohexyl alcohol,CC(C)O,OC1CCCCC1
+695,pentan-1-ol__.alpha.-toluenol,0,0,0,0,9,0,0,9,pentan-1-ol,.alpha.-toluenol,CCCCCO,OCc1ccccc1
+696,tetrahydropyran__1-nonanol,0,0,0,0,9,0,0,9,tetrahydropyran,1-nonanol,C1CCOCC1,CCCCCCCCCO
+452,"3-oxa-1,5-pentanediol__3,6-dioxa-1,8-octanediol",8,0,0,0,0,0,0,8,"3-oxa-1,5-pentanediol","3,6-dioxa-1,8-octanediol",OCCOCCO,OCCOCCOCCO
+453,isopropyl ether__isooctane,8,0,0,0,0,0,0,8,isopropyl ether,isooctane,CC(C)OC(C)C,CCCCCC(C)C
+454,"1,2-ethanediol__3-oxa-1,5-pentanediol",8,0,0,0,0,0,0,8,"1,2-ethanediol","3-oxa-1,5-pentanediol",OCCO,OCCOCCO
+455,ethylene glycol__bis(2-hydroxyethyl) ether,8,0,0,0,0,0,0,8,ethylene glycol,bis(2-hydroxyethyl) ether,OCCO,OCCOCCO
+456,"1,2-ethanediol__3,6-dioxa-1,8-octanediol",8,0,0,0,0,0,0,8,"1,2-ethanediol","3,6-dioxa-1,8-octanediol",OCCO,OCCOCCOCCO
+458,"bis(2-hydroxyethyl) ether__3,6-dioxa-1,8-octanediol",5,0,0,0,0,0,0,5,bis(2-hydroxyethyl) ether,"3,6-dioxa-1,8-octanediol",OCCOCCO,OCCOCCOCCO
+459,"ethylene glycol__3,6-dioxa-1,8-octanediol",5,0,0,0,0,0,0,5,ethylene glycol,"3,6-dioxa-1,8-octanediol",OCCO,OCCOCCOCCO
+460,methanol__2-methoxyethanol,5,0,0,0,0,0,0,5,methanol,2-methoxyethanol,CO,COCCO
+473,toluene__methoxymethane,0,5,0,0,0,0,0,5,toluene,methoxymethane,Cc1ccccc1,COC
+474,"1,4-dimethylbenzene__butane",0,5,0,0,0,0,0,5,"1,4-dimethylbenzene",butane,Cc1ccc(C)cc1,CCCC
+475,"decane__1,3-propanediol",0,5,0,0,0,0,0,5,decane,"1,3-propanediol",CCCCCCCCCC,OCCCO
+476,"propane__1,4-dimethylbenzene",0,5,0,0,0,0,0,5,propane,"1,4-dimethylbenzene",CCC,Cc1ccc(C)cc1
+477,"1,2-dimethylbenzene__methoxymethane",0,5,0,0,0,0,0,5,"1,2-dimethylbenzene",methoxymethane,Cc1ccccc1C,COC
+478,"octane__1,3-propanediol",0,5,0,0,0,0,0,5,octane,"1,3-propanediol",CCCCCCCC,OCCCO
+479,"2-methylpropane__1,4-dimethylbenzene",0,5,0,0,0,0,0,5,2-methylpropane,"1,4-dimethylbenzene",CC(C)C,Cc1ccc(C)cc1
+480,"1,4-dimethylbenzene__methoxymethane",0,5,0,0,0,0,0,5,"1,4-dimethylbenzene",methoxymethane,Cc1ccc(C)cc1,COC
+481,2-methylpropane__toluene,0,4,0,0,0,0,0,4,2-methylpropane,toluene,CC(C)C,Cc1ccccc1
+482,"butane, 2-ethoxy-2-methyl-__water",0,4,0,0,0,0,0,4,"butane, 2-ethoxy-2-methyl-",water,CCOC(C)(C)CC,O
+483,"2-methylpropane__1,2-dimethylbenzene",0,4,0,0,0,0,0,4,2-methylpropane,"1,2-dimethylbenzene",CC(C)C,Cc1ccccc1C
+484,benzene__methoxymethane,0,4,0,0,0,0,0,4,benzene,methoxymethane,c1ccccc1,COC
+485,"propane__1,2-dimethylbenzene",0,4,0,0,0,0,0,4,propane,"1,2-dimethylbenzene",CCC,Cc1ccccc1C
+486,butane__toluene,0,4,0,0,0,0,0,4,butane,toluene,CCCC,Cc1ccccc1
+487,benzene__propane,0,4,0,0,0,0,0,4,benzene,propane,c1ccccc1,CCC
+488,"2-methylpropane__1,3-dimethylbenzene",0,4,0,0,0,0,0,4,2-methylpropane,"1,3-dimethylbenzene",CC(C)C,Cc1cccc(C)c1
+489,"1,3-dimethylbenzene__methoxymethane",0,4,0,0,0,0,0,4,"1,3-dimethylbenzene",methoxymethane,Cc1cccc(C)c1,COC
+490,toluene__water,0,4,0,0,0,0,0,4,toluene,water,Cc1ccccc1,O
+491,methyl tert-butyl ether__water,0,4,0,0,0,0,0,4,methyl tert-butyl ether,water,COC(C)(C)C,O
+492,"propane__1,3-dimethylbenzene",0,4,0,0,0,0,0,4,propane,"1,3-dimethylbenzene",CCC,Cc1cccc(C)c1
+493,"1,2-dimethylbenzene__butane",0,4,0,0,0,0,0,4,"1,2-dimethylbenzene",butane,Cc1ccccc1C,CCCC
+494,tert-amyl methyl ether__water,0,4,0,0,0,0,0,4,tert-amyl methyl ether,water,CCC(C)(C)OC,O
+495,benzene__2-methylpropane,0,4,0,0,0,0,0,4,benzene,2-methylpropane,c1ccccc1,CC(C)C
+496,tert-butyl ethyl ether__water,0,4,0,0,0,0,0,4,tert-butyl ethyl ether,water,CCOC(C)(C)C,O
+497,propane__toluene,0,4,0,0,0,0,0,4,propane,toluene,CCC,Cc1ccccc1
+498,benzene__butane,0,4,0,0,0,0,0,4,benzene,butane,c1ccccc1,CCCC
+499,"butane__1,3-dimethylbenzene",0,4,0,0,0,0,0,4,butane,"1,3-dimethylbenzene",CCCC,Cc1cccc(C)c1
+464,methanol__ethane,3,0,0,0,0,0,0,3,methanol,ethane,CO,CC
+500,diethylene glycol__n-nonane,0,3,0,0,0,0,0,3,diethylene glycol,n-nonane,OCCOCCO,CCCCCCCCC
+501,triethylene glycol__n-heptane,0,3,0,0,0,0,0,3,triethylene glycol,n-heptane,OCCOCCOCCO,CCCCCCC
+502,n-octane__triethylene glycol,0,3,0,0,0,0,0,3,n-octane,triethylene glycol,CCCCCCCC,OCCOCCOCCO
+503,n-nonane__triethylene glycol,0,3,0,0,0,0,0,3,n-nonane,triethylene glycol,CCCCCCCCC,OCCOCCOCCO
+504,triethylene glycol__cycloheptane,0,3,0,0,0,0,0,3,triethylene glycol,cycloheptane,OCCOCCOCCO,C1CCCCCC1
+505,2-propanol__triethylene glycol,0,3,0,0,0,0,0,3,2-propanol,triethylene glycol,CC(C)O,OCCOCCOCCO
+506,ethanol__triethylene glycol,0,3,0,0,0,0,0,3,ethanol,triethylene glycol,CCO,OCCOCCOCCO
+507,diethylene glycol__cycloheptane,0,3,0,0,0,0,0,3,diethylene glycol,cycloheptane,OCCOCCO,C1CCCCCC1
+508,n-hexane__diethylene glycol,0,3,0,0,0,0,0,3,n-hexane,diethylene glycol,CCCCCC,OCCOCCO
+509,diethylene glycol__cyclopentane,0,3,0,0,0,0,0,3,diethylene glycol,cyclopentane,OCCOCCO,C1CCCC1
+510,cyclohexane__diethylene glycol,0,3,0,0,0,0,0,3,cyclohexane,diethylene glycol,C1CCCCC1,OCCOCCO
+511,cyclohexane__triethylene glycol,0,3,0,0,0,0,0,3,cyclohexane,triethylene glycol,C1CCCCC1,OCCOCCOCCO
+512,2-propanol__diethylene glycol,0,3,0,0,0,0,0,3,2-propanol,diethylene glycol,CC(C)O,OCCOCCO
+513,benzene__triethylene glycol,0,3,0,0,0,0,0,3,benzene,triethylene glycol,c1ccccc1,OCCOCCOCCO
+514,ethylbenzene__triethylene glycol,0,3,0,0,0,0,0,3,ethylbenzene,triethylene glycol,CCc1ccccc1,OCCOCCOCCO
+515,ethylbenzene__diethylene glycol,0,3,0,0,0,0,0,3,ethylbenzene,diethylene glycol,CCc1ccccc1,OCCOCCO
+516,1-propanol__triethylene glycol,0,3,0,0,0,0,0,3,1-propanol,triethylene glycol,CCCO,OCCOCCOCCO
+517,diethylene glycol__cyclooctane,0,3,0,0,0,0,0,3,diethylene glycol,cyclooctane,OCCOCCO,C1CCCCCCC1
+518,toluene__diethylene glycol,0,3,0,0,0,0,0,3,toluene,diethylene glycol,Cc1ccccc1,OCCOCCO
+519,n-pentane__triethylene glycol,0,3,0,0,0,0,0,3,n-pentane,triethylene glycol,CCCCC,OCCOCCOCCO
+520,diethylene glycol__n-heptane,0,3,0,0,0,0,0,3,diethylene glycol,n-heptane,OCCOCCO,CCCCCCC
+521,"hexane__1,3-propanediol",0,3,0,0,0,0,0,3,hexane,"1,3-propanediol",CCCCCC,OCCCO
+522,n-pentane__diethylene glycol,0,3,0,0,0,0,0,3,n-pentane,diethylene glycol,CCCCC,OCCOCCO
+523,methanol__diethylene glycol,0,3,0,0,0,0,0,3,methanol,diethylene glycol,CO,OCCOCCO
+524,1-propanol__diethylene glycol,0,3,0,0,0,0,0,3,1-propanol,diethylene glycol,CCCO,OCCOCCO
+525,triethylene glycol__cyclooctane,0,3,0,0,0,0,0,3,triethylene glycol,cyclooctane,OCCOCCOCCO,C1CCCCCCC1
+526,n-hexane__triethylene glycol,0,3,0,0,0,0,0,3,n-hexane,triethylene glycol,CCCCCC,OCCOCCOCCO
+527,triethylene glycol__cyclopentane,0,3,0,0,0,0,0,3,triethylene glycol,cyclopentane,OCCOCCOCCO,C1CCCC1
+528,"1,2-ethanediol__hexane",0,3,0,0,0,0,0,3,"1,2-ethanediol",hexane,OCCO,CCCCCC
+529,toluene__triethylene glycol,0,3,0,0,0,0,0,3,toluene,triethylene glycol,Cc1ccccc1,OCCOCCOCCO
+530,diethylene glycol__n-octane,0,3,0,0,0,0,0,3,diethylene glycol,n-octane,OCCOCCO,CCCCCCCC
+531,"1,2-ethanediol__decane",0,3,0,0,0,0,0,3,"1,2-ethanediol",decane,OCCO,CCCCCCCCCC
+532,ethanol__diethylene glycol,0,3,0,0,0,0,0,3,ethanol,diethylene glycol,CCO,OCCOCCO
+533,benzene__diethylene glycol,0,3,0,0,0,0,0,3,benzene,diethylene glycol,c1ccccc1,OCCOCCO
+534,methanol__triethylene glycol,0,2,0,0,0,0,0,2,methanol,triethylene glycol,CO,OCCOCCOCCO
+535,2-methylphenol__nonane,0,2,0,0,0,0,0,2,2-methylphenol,nonane,Cc1ccccc1O,CCCCCCCCC
+536,3-methylphenol__nonane,0,2,0,0,0,0,0,2,3-methylphenol,nonane,Cc1cccc(O)c1,CCCCCCCCC
+465,glycidol__water,1,0,0,0,0,0,0,1,glycidol,water,OCC1CO1,O
+537,methyl cellosolve__n-decane,0,1,0,0,0,0,0,1,methyl cellosolve,n-decane,COCCO,CCCCCCCCCC
+538,methylcyclopentane__methyl cellosolve,0,1,0,0,0,0,0,1,methylcyclopentane,methyl cellosolve,CC1CCCC1,COCCO
+539,propylene glycol__n-octane,0,1,0,0,0,0,0,1,propylene glycol,n-octane,CC(O)CO,CCCCCCCC
+540,methyl cellosolve__cyclohexane,0,1,0,0,0,0,0,1,methyl cellosolve,cyclohexane,COCCO,C1CCCCC1
+541,methyl cellosolve__cyclooctane,0,1,0,0,0,0,0,1,methyl cellosolve,cyclooctane,COCCO,C1CCCCCCC1
+542,2-methylphenol__decane,0,1,0,0,0,0,0,1,2-methylphenol,decane,Cc1ccccc1O,CCCCCCCCCC
+543,methylcyclohexane__methyl cellosolve,0,1,0,0,0,0,0,1,methylcyclohexane,methyl cellosolve,CC1CCCCC1,COCCO
+544,benzene__methyl cellosolve,0,1,0,0,0,0,0,1,benzene,methyl cellosolve,c1ccccc1,COCCO
+545,m-xylene__methyl cellosolve,0,1,0,0,0,0,0,1,m-xylene,methyl cellosolve,Cc1cccc(C)c1,COCCO
+546,propylene glycol__toluene,0,1,0,0,0,0,0,1,propylene glycol,toluene,CC(O)CO,Cc1ccccc1
+547,propylene glycol__benzene,0,1,0,0,0,0,0,1,propylene glycol,benzene,CC(O)CO,c1ccccc1
+548,o-xylene__methyl cellosolve,0,1,0,0,0,0,0,1,o-xylene,methyl cellosolve,Cc1ccccc1C,COCCO
+549,propylene glycol__ethylbenzene,0,1,0,0,0,0,0,1,propylene glycol,ethylbenzene,CC(O)CO,CCc1ccccc1
+550,propylene glycol__m-xylene,0,1,0,0,0,0,0,1,propylene glycol,m-xylene,CC(O)CO,Cc1cccc(C)c1
+551,propylene glycol__naphthalene,0,1,0,0,0,0,0,1,propylene glycol,naphthalene,CC(O)CO,c1ccc2ccccc2c1
+552,3-methylphenol__decane,0,1,0,0,0,0,0,1,3-methylphenol,decane,Cc1cccc(O)c1,CCCCCCCCCC
+553,p-cymene__methyl cellosolve,0,1,0,0,0,0,0,1,p-cymene,methyl cellosolve,CC(C)c1ccc(C)cc1,COCCO
+554,toluene__methyl cellosolve,0,1,0,0,0,0,0,1,toluene,methyl cellosolve,Cc1ccccc1,COCCO
+555,naphthalene__methyl cellosolve,0,1,0,0,0,0,0,1,naphthalene,methyl cellosolve,c1ccc2ccccc2c1,COCCO
+556,propylene glycol__n-heptane,0,1,0,0,0,0,0,1,propylene glycol,n-heptane,CC(O)CO,CCCCCCC
+557,ethylbenzene__methyl cellosolve,0,1,0,0,0,0,0,1,ethylbenzene,methyl cellosolve,CCc1ccccc1,COCCO
+558,p-xylene__methyl cellosolve,0,1,0,0,0,0,0,1,p-xylene,methyl cellosolve,Cc1ccc(C)cc1,COCCO
+559,methyl cellosolve__n-heptane,0,1,0,0,0,0,0,1,methyl cellosolve,n-heptane,COCCO,CCCCCCC
+560,methyl cellosolve__n-hexane,0,1,0,0,0,0,0,1,methyl cellosolve,n-hexane,COCCO,CCCCCC
+561,propylene glycol__n-hexane,0,1,0,0,0,0,0,1,propylene glycol,n-hexane,CC(O)CO,CCCCCC
+562,methyl cellosolve__n-nonane,0,1,0,0,0,0,0,1,methyl cellosolve,n-nonane,COCCO,CCCCCCCCC
+563,propylene glycol__o-xylene,0,1,0,0,0,0,0,1,propylene glycol,o-xylene,CC(O)CO,Cc1ccccc1C
+564,propylene glycol__p-xylene,0,1,0,0,0,0,0,1,propylene glycol,p-xylene,CC(O)CO,Cc1ccc(C)cc1
+565,methyl cellosolve__n-octane,0,1,0,0,0,0,0,1,methyl cellosolve,n-octane,COCCO,CCCCCCCC

--- a/Initial Molecule Choices/mix_counts_intersting_diverse.csv
+++ b/Initial Molecule Choices/mix_counts_intersting_diverse.csv
@@ -1,0 +1,181 @@
+,Mixture,Mixture Count dens binary,Mixture Count actcoeff binary,Mixture Count sos binary,Mixture Count dielec binary,Mixture Count eme binary,Mixture Count emcp binary,Mixture Count emv binary,Mixture Count all,x1,x2,SMILES1,SMILES2
+1,2-propanol__water,1012,0,0,0,45,0,0,1057,2-propanol,water,CC(C)O,O
+3,ethanol__water,712,0,20,0,83,0,0,815,ethanol,water,CCO,O
+5,ethanol__methylcyclohexane,753,0,11,0,0,0,0,764,ethanol,methylcyclohexane,CCO,CC1CCCCC1
+7,ethanol__heptane,708,0,39,0,0,0,0,747,ethanol,heptane,CCO,CCCCCCC
+8,2-methyl-2-propanol__water,636,0,6,0,0,0,0,642,2-methyl-2-propanol,water,CC(C)(C)O,O
+9,1-butanol__cyclohexane,501,0,51,0,38,0,0,590,1-butanol,cyclohexane,CCCCO,C1CCCCC1
+10,tert-pentyl alcohol__heptane,102,0,450,0,0,0,0,552,tert-pentyl alcohol,heptane,CCC(C)(C)O,CCCCCCC
+12,1-propoxy-2-propanol__water,318,0,145,0,0,0,0,463,1-propoxy-2-propanol,water,CCCOCC(C)O,O
+20,methanol__water,212,0,12,0,140,0,0,364,methanol,water,CO,O
+21,tert-butanol__water,360,0,0,0,0,0,0,360,tert-butanol,water,CC(C)(C)O,O
+24,n-butyl alcohol__2-methylheptane,324,0,0,0,0,0,0,324,n-butyl alcohol,2-methylheptane,CCCCO,CCCCCC(C)C
+39,ethanol__methanol,63,0,0,105,76,0,0,244,ethanol,methanol,CCO,CO
+41,tetrahydrofuran__water,220,0,20,0,0,0,0,240,tetrahydrofuran,water,C1CCOC1,O
+46,neopentyl alcohol__water,213,0,0,0,0,0,0,213,neopentyl alcohol,water,CC(C)(C)CO,O
+48,"1-butanol__2,2,4-trimethylpentane",93,0,80,0,38,0,0,211,1-butanol,"2,2,4-trimethylpentane",CCCCO,CC(C)CC(C)(C)C
+49,"2-methyl-1,3-propanediol__water",209,0,0,0,0,0,0,209,"2-methyl-1,3-propanediol",water,CC(CO)CO,O
+54,1-propanol__water,172,0,27,0,0,0,0,199,1-propanol,water,CCCO,O
+62,1-butanol__hexane,60,0,60,0,23,0,31,174,1-butanol,hexane,CCCCO,CCCCCC
+65,"ethanol__2,2,4-trimethylpentane",150,0,0,0,19,0,0,169,ethanol,"2,2,4-trimethylpentane",CCO,CC(C)CC(C)(C)C
+67,2-propanol__cyclohexane,78,0,78,0,9,0,0,165,2-propanol,cyclohexane,CC(C)O,C1CCCCC1
+71,"2,2-dimethyl-1,3-propanediol__water",156,0,0,0,0,0,0,156,"2,2-dimethyl-1,3-propanediol",water,CC(C)(CO)CO,O
+74,ethanol__cyclohexane,111,0,39,0,0,0,0,150,ethanol,cyclohexane,CCO,C1CCCCC1
+78,ethanol__isooctane,72,0,72,0,0,0,0,144,ethanol,isooctane,CCO,CCCCCC(C)C
+91,"3-methylpentane-1,5-diol__water",138,0,0,0,0,0,0,138,"3-methylpentane-1,5-diol",water,CC(CCO)CCO,O
+95,ethanol__2-methyl-1-butanol,116,0,18,0,0,0,0,134,ethanol,2-methyl-1-butanol,CCO,CCC(C)CO
+101,1-propanol__tert-butanol,66,0,66,0,0,0,0,132,1-propanol,tert-butanol,CCCO,CC(C)(C)O
+103,2-propanol__tert-butanol,66,0,66,0,0,0,0,132,2-propanol,tert-butanol,CC(C)O,CC(C)(C)O
+117,ethanol__hexane,39,0,39,0,17,0,23,118,ethanol,hexane,CCO,CCCCCC
+125,"1-propanol__2,2,4-trimethylpentane",108,0,0,0,0,0,0,108,1-propanol,"2,2,4-trimethylpentane",CCCO,CC(C)CC(C)(C)C
+133,2-methoxyethanol__tert-butyl ethyl ether,105,0,0,0,0,0,0,105,2-methoxyethanol,tert-butyl ethyl ether,COCCO,CCOC(C)(C)C
+135,methanol__2-propanol,0,0,0,105,0,0,0,105,methanol,2-propanol,CO,CC(C)O
+136,methanol__2-methyl-1-propanol,0,0,0,105,0,0,0,105,methanol,2-methyl-1-propanol,CO,CC(C)CO
+137,methanol__1-butanol,0,0,0,105,0,0,0,105,methanol,1-butanol,CO,CCCCO
+138,methanol__1-propanol,0,0,0,105,0,0,0,105,methanol,1-propanol,CO,CCCO
+141,1-propanol__cyclopentane,63,0,39,0,0,0,0,102,1-propanol,cyclopentane,CCCO,C1CCCC1
+145,ethanol__3-methyl-1-butanol,98,0,0,0,0,0,0,98,ethanol,3-methyl-1-butanol,CCO,CC(C)CCO
+146,ethanol__2-methyl-2-butanol,98,0,0,0,0,0,0,98,ethanol,2-methyl-2-butanol,CCO,CCC(C)(C)O
+153,2-methoxyethanol__1-hexanol,48,0,48,0,0,0,0,96,2-methoxyethanol,1-hexanol,COCCO,CCCCCCO
+155,tetrahydrofuran__n-hexyl alcohol,48,0,48,0,0,0,0,96,tetrahydrofuran,n-hexyl alcohol,C1CCOC1,CCCCCCO
+162,methanol__2-methyl-2-propanol,0,0,0,95,0,0,0,95,methanol,2-methyl-2-propanol,CO,CC(C)(C)O
+163,1-butanol__water,75,8,11,0,0,0,0,94,1-butanol,water,CCCCO,O
+164,1-butanol__2-methyltetrahydrofuran,27,0,34,0,33,0,0,94,1-butanol,2-methyltetrahydrofuran,CCCCO,CC1CCCO1
+166,1-butanol__heptane,55,0,0,0,38,0,0,93,1-butanol,heptane,CCCCO,CCCCCCC
+169,oxacyclopentane__water,90,0,0,0,0,0,0,90,oxacyclopentane,water,C1CCOC1,O
+171,2-(2-methylpropoxy)ethanol__water,45,0,45,0,0,0,0,90,2-(2-methylpropoxy)ethanol,water,CC(C)COCCO,O
+172,1-propanol__cyclohexane,50,0,39,0,0,0,0,89,1-propanol,cyclohexane,CCCO,C1CCCCC1
+173,1-butanol__cyclopentane,39,0,39,0,11,0,0,89,1-butanol,cyclopentane,CCCCO,C1CCCC1
+174,ethyl alcohol__n-butyl alcohol,88,0,0,0,0,0,0,88,ethyl alcohol,n-butyl alcohol,CCO,CCCCO
+178,ethyl alcohol__pentan-1-ol,88,0,0,0,0,0,0,88,ethyl alcohol,pentan-1-ol,CCO,CCCCCO
+179,ethyl alcohol__propan-1-ol,88,0,0,0,0,0,0,88,ethyl alcohol,propan-1-ol,CCO,CCCO
+181,"2-methoxyethanol__ethanol, 2-ethoxy-",44,0,44,0,0,0,0,88,2-methoxyethanol,"ethanol, 2-ethoxy-",COCCO,CCOCCO
+183,"2-propanol__1,3-dioxolane",74,0,11,0,0,0,0,85,2-propanol,"1,3-dioxolane",CC(C)O,C1COCO1
+184,"2-propanol__pentane, 2,2,4-trimethyl-",84,0,0,0,0,0,0,84,2-propanol,"pentane, 2,2,4-trimethyl-",CC(C)O,CC(C)CC(C)(C)C
+185,"tetrahydropyran__pentane, 2,2,4-trimethyl-",84,0,0,0,0,0,0,84,tetrahydropyran,"pentane, 2,2,4-trimethyl-",C1CCOCC1,CC(C)CC(C)(C)C
+186,"1-hexanol__2,2,4-trimethylpentane",84,0,0,0,0,0,0,84,1-hexanol,"2,2,4-trimethylpentane",CCCCCCO,CC(C)CC(C)(C)C
+188,2-propanol__tetrahydropyran,84,0,0,0,0,0,0,84,2-propanol,tetrahydropyran,CC(C)O,C1CCOCC1
+193,1-butanol__methylcyclohexane,33,0,11,0,38,0,0,82,1-butanol,methylcyclohexane,CCCCO,CC1CCCCC1
+194,1-butanol__2-methyl-1-propanol,81,0,0,0,0,0,0,81,1-butanol,2-methyl-1-propanol,CCCCO,CC(C)CO
+196,2-methyl-1-propanol__water,79,0,0,0,0,0,0,79,2-methyl-1-propanol,water,CC(C)CO,O
+197,"1-pentanol__2,2,4-trimethylpentane",79,0,0,0,0,0,0,79,1-pentanol,"2,2,4-trimethylpentane",CCCCCO,CC(C)CC(C)(C)C
+198,2-propanol__cyclopentane,39,0,39,0,0,0,0,78,2-propanol,cyclopentane,CC(C)O,C1CCCC1
+199,ethanol__cyclopentane,39,0,39,0,0,0,0,78,ethanol,cyclopentane,CCO,C1CCCC1
+206,2-methyl-2-propanol__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,2-methyl-2-propanol,tert-butyl ethyl ether,CC(C)(C)O,CCOC(C)(C)C
+207,"2,2,4-trimethylpentane__tert-butyl ethyl ether",39,0,39,0,0,0,0,78,"2,2,4-trimethylpentane",tert-butyl ethyl ether,CC(C)CC(C)(C)C,CCOC(C)(C)C
+208,cyclopentane__2-pentanol,39,0,39,0,0,0,0,78,cyclopentane,2-pentanol,C1CCCC1,CCCC(C)O
+209,2-methyl-2-butanol__tetrahydrofuran,39,0,0,0,0,0,39,78,2-methyl-2-butanol,tetrahydrofuran,CCC(C)(C)O,C1CCOC1
+210,ethanol__tert-butyl ethyl ether,39,0,39,0,0,0,0,78,ethanol,tert-butyl ethyl ether,CCO,CCOC(C)(C)C
+218,ethanol__2-propanol,0,0,0,0,76,0,0,76,ethanol,2-propanol,CCO,CC(C)O
+220,ethanol__1-propanol,0,0,0,0,74,0,0,74,ethanol,1-propanol,CCO,CCCO
+221,1-butanol__2-methyl-2-propanol,72,0,0,0,0,0,0,72,1-butanol,2-methyl-2-propanol,CCCCO,CC(C)(C)O
+223,tert-butanol__heptane,70,0,0,0,0,0,0,70,tert-butanol,heptane,CC(C)(C)O,CCCCCCC
+224,1-butanol__tetrahydropyran,0,0,35,0,33,0,0,68,1-butanol,tetrahydropyran,CCCCO,C1CCOCC1
+237,methanol__cyclohexane,64,0,0,0,0,0,0,64,methanol,cyclohexane,CO,C1CCCCC1
+244,ethanol__2-methyl-2-propanol,63,0,0,0,0,0,0,63,ethanol,2-methyl-2-propanol,CCO,CC(C)(C)O
+246,"2,2,4-trimethylpentane__1,3-dioxolane",63,0,0,0,0,0,0,63,"2,2,4-trimethylpentane","1,3-dioxolane",CC(C)CC(C)(C)C,C1COCO1
+248,"2-methyl-2-propanol__2,2,4-trimethylpentane",63,0,0,0,0,0,0,63,2-methyl-2-propanol,"2,2,4-trimethylpentane",CC(C)(C)O,CC(C)CC(C)(C)C
+256,cyclohexane__tetrahydropyran,0,0,13,0,32,0,14,59,cyclohexane,tetrahydropyran,C1CCCCC1,C1CCOCC1
+259,"ethanol, 2-ethoxy-__cyclohexane",0,0,0,0,58,0,0,58,"ethanol, 2-ethoxy-",cyclohexane,CCOCCO,C1CCCCC1
+262,n-propanol__water,56,0,0,0,0,0,0,56,n-propanol,water,CCCO,O
+263,"1-hexanol__1,4-dioxane",56,0,0,0,0,0,0,56,1-hexanol,"1,4-dioxane",CCCCCCO,C1COCCO1
+266,2-propanol__1-propanol,55,0,0,0,0,0,0,55,2-propanol,1-propanol,CC(C)O,CCCO
+272,1-propanol__isopropyl ether,32,0,21,0,0,0,0,53,1-propanol,isopropyl ether,CCCO,CC(C)OC(C)C
+285,"cyclohexane__1,4-dioxane",0,0,33,0,19,0,0,52,cyclohexane,"1,4-dioxane",C1CCCCC1,C1COCCO1
+286,"hexane__ethanol, 2-ethoxy-",0,0,0,0,51,0,0,51,hexane,"ethanol, 2-ethoxy-",CCCCCC,CCOCCO
+287,1-pentanol__cyclohexane,0,0,0,0,51,0,0,51,1-pentanol,cyclohexane,CCCCCO,C1CCCCC1
+294,"2,2,4-trimethylpentane__butane, 2-methoxy-2-methyl-",48,0,0,0,0,0,0,48,"2,2,4-trimethylpentane","butane, 2-methoxy-2-methyl-",CC(C)CC(C)(C)C,CCC(C)(C)OC
+302,1-hexanol__heptane,45,0,0,0,0,0,0,45,1-hexanol,heptane,CCCCCCO,CCCCCCC
+303,isopropanol__isobutyl alcohol,45,0,0,0,0,0,0,45,isopropanol,isobutyl alcohol,CC(C)O,CC(C)CO
+309,n-propyl alcohol__isobutyl alcohol,44,0,0,0,0,0,0,44,n-propyl alcohol,isobutyl alcohol,CCCO,CC(C)CO
+311,1-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,1-propanol,methylcyclohexane,CCCO,CC1CCCCC1
+315,2-methyl-1-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,2-methyl-1-propanol,methylcyclohexane,CC(C)CO,CC1CCCCC1
+316,methylcyclohexane__3-methyl-1-butanol,33,0,11,0,0,0,0,44,methylcyclohexane,3-methyl-1-butanol,CC1CCCCC1,CC(C)CCO
+318,2-propanol__methylcyclohexane,33,0,11,0,0,0,0,44,2-propanol,methylcyclohexane,CC(C)O,CC1CCCCC1
+322,ethanol__isopropyl ether,24,0,0,0,19,0,0,43,ethanol,isopropyl ether,CCO,CC(C)OC(C)C
+330,ethylene glycol methyl ether__water,21,0,21,0,0,0,0,42,ethylene glycol methyl ether,water,COCCO,O
+331,1-propanol__tert-amyl methyl ether,21,0,21,0,0,0,0,42,1-propanol,tert-amyl methyl ether,CCCO,CCC(C)(C)OC
+333,"isopropyl ether__2,2,4-trimethylpentane",13,0,10,0,19,0,0,42,isopropyl ether,"2,2,4-trimethylpentane",CC(C)OC(C)C,CC(C)CC(C)(C)C
+335,n-hexane__tetrahydropyran,0,0,14,0,14,0,14,42,n-hexane,tetrahydropyran,CCCCCC,C1CCOCC1
+337,tetrahydropyran__heptane,0,0,14,0,14,0,14,42,tetrahydropyran,heptane,C1CCOCC1,CCCCCCC
+339,n-heptane__2-pentanol,0,0,0,0,42,0,0,42,n-heptane,2-pentanol,CCCCCCC,CCCC(C)O
+340,pentan-1-ol__isooctane,0,0,0,0,42,0,0,42,pentan-1-ol,isooctane,CCCCCO,CCCCCC(C)C
+342,pentan-1-ol__heptane,0,0,0,0,42,0,0,42,pentan-1-ol,heptane,CCCCCO,CCCCCCC
+343,"2,2,4-trimethylpentane__2-pentanol",0,0,0,0,42,0,0,42,"2,2,4-trimethylpentane",2-pentanol,CC(C)CC(C)(C)C,CCCC(C)O
+346,cyclohexane__2-pentanol,39,0,0,0,0,0,0,39,cyclohexane,2-pentanol,C1CCCCC1,CCCC(C)O
+348,1-propanol__2-methyl-1-butanol,19,0,19,0,0,0,0,38,1-propanol,2-methyl-1-butanol,CCCO,CCC(C)CO
+349,1-propanol__3-methyl-1-butanol,19,0,19,0,0,0,0,38,1-propanol,3-methyl-1-butanol,CCCO,CC(C)CCO
+350,methanol__2-methyl-1-butanol,19,0,19,0,0,0,0,38,methanol,2-methyl-1-butanol,CO,CCC(C)CO
+351,"hexane__ether, methyl tert-pentyl",19,0,0,0,0,0,19,38,hexane,"ether, methyl tert-pentyl",CCCCCC,CCC(C)(C)OC
+358,1-pentanol__cyclopentane,26,0,0,0,10,0,0,36,1-pentanol,cyclopentane,CCCCCO,C1CCCC1
+360,2-isopropoxyethanol__water,18,0,18,0,0,0,0,36,2-isopropoxyethanol,water,CC(C)OCCO,O
+372,"1,4-dioxane__cyclopentane",0,0,33,0,0,0,0,33,"1,4-dioxane",cyclopentane,C1COCCO1,C1CCCC1
+374,2-methyl-1-propanol__hexane,16,0,16,0,0,0,0,32,2-methyl-1-propanol,hexane,CC(C)CO,CCCCCC
+379,propan-1-ol__water,30,0,0,0,0,0,0,30,propan-1-ol,water,CCCO,O
+396,"ethanol, 2-ethoxy-__water",12,0,16,0,0,0,0,28,"ethanol, 2-ethoxy-",water,CCOCCO,O
+397,"1,4-dioxane__water",10,0,18,0,0,0,0,28,"1,4-dioxane",water,C1COCCO1,O
+402,"cyclopentane__1,3-dioxolane",0,0,27,0,0,0,0,27,cyclopentane,"1,3-dioxolane",C1CCCC1,C1COCO1
+403,"cyclohexane__1,3-dioxolane",0,0,27,0,0,0,0,27,cyclohexane,"1,3-dioxolane",C1CCCCC1,C1COCO1
+409,n-propyl alcohol__water,25,0,0,0,0,0,0,25,n-propyl alcohol,water,CCCO,O
+415,2-ethoxyethanol__water,24,0,0,0,0,0,0,24,2-ethoxyethanol,water,CCOCCO,O
+418,isobutanol__water,12,0,12,0,0,0,0,24,isobutanol,water,CC(C)CO,O
+420,"ethane, 1,1'-oxybis-__1,3-dioxolane",11,0,12,0,0,0,0,23,"ethane, 1,1'-oxybis-","1,3-dioxolane",CCOCC,C1COCO1
+421,neohexane__tetrahydrofuran,0,0,0,0,23,0,0,23,neohexane,tetrahydrofuran,CCC(C)(C)C,C1CCOC1
+422,diisopropyl__tetrahydrofuran,0,0,0,0,23,0,0,23,diisopropyl,tetrahydrofuran,CC(C)C(C)C,C1CCOC1
+436,1-propanol__1-pentanol,22,0,0,0,0,0,0,22,1-propanol,1-pentanol,CCCO,CCCCCO
+441,"ethane, 1,1'-oxybis-__pentan-1-ol",11,0,11,0,0,0,0,22,"ethane, 1,1'-oxybis-",pentan-1-ol,CCOCC,CCCCCO
+442,"2-methoxyethanol__1,3-dioxolane",11,0,11,0,0,0,0,22,2-methoxyethanol,"1,3-dioxolane",COCCO,C1COCO1
+443,"pentan-1-ol__1,3-dioxolane",11,0,11,0,0,0,0,22,pentan-1-ol,"1,3-dioxolane",CCCCCO,C1COCO1
+444,"ethanol, 2-ethoxy-__1,3-dioxolane",11,0,11,0,0,0,0,22,"ethanol, 2-ethoxy-","1,3-dioxolane",CCOCCO,C1COCO1
+451,"2,3-dimethylbutane__ether, dipropyl",0,0,0,0,20,0,0,20,"2,3-dimethylbutane","ether, dipropyl",CC(C)C(C)C,CCCOCCC
+454,tetramethylene oxide__dipropyl ether,0,0,0,0,20,0,0,20,tetramethylene oxide,dipropyl ether,C1CCOC1,CCCOCCC
+457,2-methyl-1-propanol__2-methyl-1-butanol,19,0,0,0,0,0,0,19,2-methyl-1-propanol,2-methyl-1-butanol,CC(C)CO,CCC(C)CO
+458,2-methyl-1-propanol__3-methyl-1-butanol,19,0,0,0,0,0,0,19,2-methyl-1-propanol,3-methyl-1-butanol,CC(C)CO,CC(C)CCO
+459,1-propanol__tert-butyl ethyl ether,19,0,0,0,0,0,0,19,1-propanol,tert-butyl ethyl ether,CCCO,CCOC(C)(C)C
+460,1-pentanol__2-methyl-1-propanol,19,0,0,0,0,0,0,19,1-pentanol,2-methyl-1-propanol,CCCCCO,CC(C)CO
+462,"butane, 2,2-dimethyl-__ether, dipropyl",0,0,0,0,19,0,0,19,"butane, 2,2-dimethyl-","ether, dipropyl",CCC(C)(C)C,CCCOCCC
+465,methanol__methoxymethane,0,0,0,0,19,0,0,19,methanol,methoxymethane,CO,COC
+468,1-propanol__methoxymethane,0,0,0,0,19,0,0,19,1-propanol,methoxymethane,CCCO,COC
+470,ethanol__methoxymethane,0,0,0,0,19,0,0,19,ethanol,methoxymethane,CCO,COC
+471,1-butanol__methoxymethane,0,0,0,0,19,0,0,19,1-butanol,methoxymethane,CCCCO,COC
+475,ethanol__tetrahydropyran,0,0,0,0,19,0,0,19,ethanol,tetrahydropyran,CCO,C1CCOCC1
+482,1-pentanol__hexane,0,0,0,0,18,0,0,18,1-pentanol,hexane,CCCCCO,CCCCCC
+488,2-methyl-1-propanol__1-methyl-1-(1-methylethoxy)ethane,0,0,0,0,17,0,0,17,2-methyl-1-propanol,1-methyl-1-(1-methylethoxy)ethane,CC(C)CO,CC(C)OC(C)C
+490,methanol__dioxane,16,0,0,0,0,0,0,16,methanol,dioxane,CO,C1COCCO1
+491,tert-pentyl alcohol__water,0,16,0,0,0,0,0,16,tert-pentyl alcohol,water,CCC(C)(C)O,O
+492,2-methoxyethanol__water,0,0,16,0,0,0,0,16,2-methoxyethanol,water,COCCO,O
+493,1-propanol__heptane,0,0,0,0,16,0,0,16,1-propanol,heptane,CCCO,CCCCCCC
+494,"1-butanol, 3-methyl-__water",0,15,0,0,0,0,0,15,"1-butanol, 3-methyl-",water,CC(C)CCO,O
+495,2-methyl-1-butanol__water,0,15,0,0,0,0,0,15,2-methyl-1-butanol,water,CCC(C)CO,O
+503,ethanol__oxane,13,0,0,0,0,0,0,13,ethanol,oxane,CCO,C1CCOCC1
+507,pentan-2-ol__water,0,13,0,0,0,0,0,13,pentan-2-ol,water,CCCC(C)O,O
+509,1-butanol__1-methyl-1-(1-methylethoxy)ethane,0,0,0,0,13,0,0,13,1-butanol,1-methyl-1-(1-methylethoxy)ethane,CCCCO,CC(C)OC(C)C
+511,"1,3-dioxolane__water",12,0,0,0,0,0,0,12,"1,3-dioxolane",water,C1COCO1,O
+512,2-propanol__methane,12,0,0,0,0,0,0,12,2-propanol,methane,CC(C)O,C
+513,methanol__tetrahydrofuran,12,0,0,0,0,0,0,12,methanol,tetrahydrofuran,CO,C1CCOC1
+514,1-methyl-1-(1-methylethoxy)ethane__heptane,0,0,0,0,12,0,0,12,1-methyl-1-(1-methylethoxy)ethane,heptane,CC(C)OC(C)C,CCCCCCC
+527,1-hexanol__cyclopentane,0,0,0,0,11,0,0,11,1-hexanol,cyclopentane,CCCCCCO,C1CCCC1
+532,2-propanol__ethane,10,0,0,0,0,0,0,10,2-propanol,ethane,CC(C)O,CC
+535,3-methyl-2-butanol__water,0,10,0,0,0,0,0,10,3-methyl-2-butanol,water,CC(C)C(C)O,O
+536,isopropyl ether__hexane,0,0,10,0,0,0,0,10,isopropyl ether,hexane,CC(C)OC(C)C,CCCCCC
+537,isopropyl ether__heptane,0,0,10,0,0,0,0,10,isopropyl ether,heptane,CC(C)OC(C)C,CCCCCCC
+540,pentan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,pentan-1-ol,tert-pentyl alcohol,CCCCCO,CCC(C)(C)O
+544,ethanol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,ethanol,tert-pentyl alcohol,CCO,CCC(C)(C)O
+545,butan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,butan-1-ol,tert-pentyl alcohol,CCCCO,CCC(C)(C)O
+551,propan-1-ol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,propan-1-ol,tert-pentyl alcohol,CCCO,CCC(C)(C)O
+554,methanol__tert-pentyl alcohol,0,0,0,0,10,0,0,10,methanol,tert-pentyl alcohol,CO,CCC(C)(C)O
+555,(RS)-2-butanol__water,9,0,0,0,0,0,0,9,(RS)-2-butanol,water,CCC(C)O,O
+560,isopropyl ether__cyclohexane,0,0,9,0,0,0,0,9,isopropyl ether,cyclohexane,CC(C)OC(C)C,C1CCCCC1
+565,1-pentanol__tetrahydropyran,0,0,0,0,9,0,0,9,1-pentanol,tetrahydropyran,CCCCCO,C1CCOCC1
+568,"1,4-dioxane__tetrahydropyran",0,0,0,0,9,0,0,9,"1,4-dioxane",tetrahydropyran,C1COCCO1,C1CCOCC1
+575,isopropyl ether__isooctane,8,0,0,0,0,0,0,8,isopropyl ether,isooctane,CC(C)OC(C)C,CCCCCC(C)C
+581,methanol__2-methoxyethanol,5,0,0,0,0,0,0,5,methanol,2-methoxyethanol,CO,COCCO
+603,tert-amyl methyl ether__water,0,4,0,0,0,0,0,4,tert-amyl methyl ether,water,CCC(C)(C)OC,O
+605,tert-butyl ethyl ether__water,0,4,0,0,0,0,0,4,tert-butyl ethyl ether,water,CCOC(C)(C)C,O
+609,methanol__ethane,3,0,0,0,0,0,0,3,methanol,ethane,CO,CC
+649,methylcyclopentane__methyl cellosolve,0,1,0,0,0,0,0,1,methylcyclopentane,methyl cellosolve,CC1CCCC1,COCCO
+651,methyl cellosolve__cyclohexane,0,1,0,0,0,0,0,1,methyl cellosolve,cyclohexane,COCCO,C1CCCCC1
+652,methyl cellosolve__cyclooctane,0,1,0,0,0,0,0,1,methyl cellosolve,cyclooctane,COCCO,C1CCCCCCC1
+654,methylcyclohexane__methyl cellosolve,0,1,0,0,0,0,0,1,methylcyclohexane,methyl cellosolve,CC1CCCCC1,COCCO
+670,methyl cellosolve__n-heptane,0,1,0,0,0,0,0,1,methyl cellosolve,n-heptane,COCCO,CCCCCCC
+671,methyl cellosolve__n-hexane,0,1,0,0,0,0,0,1,methyl cellosolve,n-hexane,COCCO,CCCCCC

--- a/Initial Molecule Choices/purecomp_counts_all.csv
+++ b/Initial Molecule Choices/purecomp_counts_all.csv
@@ -1,4 +1,4 @@
-,Component,SMILES,Component Count dens pure,Component Count cpmol pure,Component Count sos pure,Component Count dielec pure,Component Count hmol pure,Component Count vmol pure,Component Count vspec pure,Component Count all pure 
+,Component,SMILES,Component Count dens pure,Component Count cpmol pure,Component Count sos pure,Component Count dielec pure,Component Count hmol pure,Component Count vmol pure,Component Count vspec pure,Component Count all
 0,decane,CCCCCCCCCC,9289,8,21,0,0,0,0,9318
 1,1-butanol,CCCCO,1327,49,85,11,0,0,0,1472
 2,heptane,CCCCCCC,1254,39,132,3,12,1,0,1441

--- a/Initial Molecule Choices/purecomp_counts_diverse.csv
+++ b/Initial Molecule Choices/purecomp_counts_diverse.csv
@@ -1,0 +1,60 @@
+,Component,SMILES,Component Count dens pure,Component Count cpmol pure,Component Count sos pure,Component Count dielec pure,Component Count hmol pure,Component Count vmol pure,Component Count vspec pure,Component Count all
+1,1-butanol,CCCCO,1327,49,85,11,0,0,0,1472
+2,heptane,CCCCCCC,1254,39,132,3,12,1,0,1441
+3,ethanol,CCO,1169,86,91,8,0,0,2,1356
+4,water,O,634,54,183,31,0,0,39,941
+6,methanol,CO,606,75,142,7,0,0,0,830
+7,1-propanol,CCCO,659,18,78,7,0,0,0,762
+8,2-methyl-1-propanol,CC(C)CO,721,0,15,5,0,0,0,741
+9,1-hexanol,CCCCCCO,664,8,64,2,0,0,0,738
+10,1-pentanol,CCCCCO,396,0,78,10,0,0,0,484
+11,cyclohexane,C1CCCCC1,368,21,55,0,0,11,0,455
+13,2-propanol,CC(C)O,357,6,53,5,0,0,0,421
+18,methoxymethane,COC,108,81,0,145,0,0,0,334
+21,hexane,CCCCCC,196,0,93,0,0,0,0,289
+27,2-methyl-2-butanol,CCC(C)(C)O,37,88,43,0,0,0,0,168
+30,2-hexanol,CCCCC(C)O,154,0,2,0,0,0,0,156
+32,methylcyclohexane,CC1CCCCC1,142,0,8,0,0,0,0,150
+34,tetrahydrofuran,C1CCOC1,96,0,43,0,0,1,0,140
+36,2-methyl-1-butanol,CCC(C)CO,11,73,43,0,0,0,0,127
+40,dimethoxymethane,COCOC,119,0,0,0,0,0,0,119
+42,2-methylheptane,CCCCCC(C)C,107,10,0,0,0,0,0,117
+45,"1,4-dioxane",C1COCCO1,77,0,32,3,0,0,0,112
+47,"2,3-dimethylbutane",CC(C)C(C)C,101,0,0,0,0,0,0,101
+48,"2,2-dimethylbutane",CCC(C)(C)C,101,0,0,0,0,0,0,101
+49,3-methylpentane,CCC(C)CC,100,0,0,0,0,0,0,100
+50,2-methylpentane,CCCC(C)C,100,0,0,0,0,0,0,100
+55,butan-2-ol,CCC(C)O,75,0,13,0,0,0,0,88
+56,2-methyl-2-propanol,CC(C)(C)O,65,0,16,0,0,0,0,81
+60,2-pentanol,CCCC(C)O,26,47,6,0,0,0,0,79
+63,isopropyl ether,CC(C)OC(C)C,47,0,22,0,0,0,0,69
+64,neopentyl alcohol,CC(C)(C)CO,0,61,0,0,5,0,0,66
+65,tetrahydropyran,C1CCOCC1,35,11,19,0,0,0,0,65
+66,diethyl ether,CCOCC,61,0,1,0,0,0,0,62
+67,2-methylpropane,CC(C)C,58,0,0,0,0,0,0,58
+68,"2,2,4-trimethylpentane",CC(C)CC(C)(C)C,45,0,12,0,0,0,0,57
+69,tert-butyl ethyl ether,CCOC(C)(C)C,32,0,24,0,0,0,0,56
+70,butane,CCCC,50,0,0,0,0,0,0,50
+73,2-methoxyethanol,COCCO,35,0,10,0,0,0,0,45
+75,3-methyl-1-butanol,CC(C)CCO,37,0,4,0,0,0,0,41
+77,"ethanol, 2-ethoxy-",CCOCCO,28,0,11,0,0,0,0,39
+79,cyclopentane,C1CCCC1,18,0,15,0,0,0,0,33
+80,3-methyl-2-butanol,CC(C)C(C)O,0,30,0,0,0,0,0,30
+83,ethane,CC,25,0,0,0,0,0,0,25
+86,"1,3-dioxolane",C1COCO1,13,0,11,0,0,0,0,24
+88,2-methyltetrahydrofuran,CC1CCCO1,10,8,4,0,0,0,0,22
+91,1-propoxy-2-propanol,CCCOCC(C)O,10,0,10,0,0,0,0,20
+94,cyclooctane,C1CCCCCCC1,12,0,4,0,0,0,0,16
+95,pentane,CCCCC,15,0,0,0,0,0,0,15
+97,2-heptanol,CCCCCC(C)O,11,1,2,0,0,0,0,14
+105,propylene glycol monoethyl ether,CCOCC(C)O,5,0,5,0,0,0,0,10
+109,dipropyl ether,CCCOCCC,9,0,0,0,0,0,0,9
+111,"ether, ethyl butyl",CCCCOCC,8,0,0,0,0,0,0,8
+117,"ethanol, 2-propoxy-",CCCOCCO,4,0,0,3,0,0,0,7
+125,methylcyclopentane,CC1CCCC1,3,0,3,0,0,0,0,6
+135,tert-amyl methyl ether,CCC(C)(C)OC,3,0,1,0,0,0,0,4
+136,4-methyl-2-pentanol,CC(C)CC(C)O,3,0,0,0,0,0,0,3
+137,2-methyl-1-pentanol,CCCC(C)CO,3,0,0,0,0,0,0,3
+138,2-methyl-2-pentanol,CCCC(C)(C)O,3,0,0,0,0,0,0,3
+142,"1,1-diethoxyethane",CCOC(C)OCC,3,0,0,0,0,0,0,3
+148,2-isopropoxyethanol,CC(C)OCCO,1,0,1,0,0,0,0,2

--- a/Python/diversitychk.py
+++ b/Python/diversitychk.py
@@ -9,16 +9,46 @@ Created on Sun May  8 18:29:53 2016
 
 import pandas as pd
 
-a = pd.read_csv("/home/bmanubay/.thermoml/tables/Ken/allcomp_counts_all.csv")
+a0 = pd.read_csv("/home/bmanubay/.thermoml/tables/Ken/allcomp_counts_all.csv")
+a1 = pd.read_csv("/home/bmanubay/.thermoml/tables/Ken/allcomp_counts_interesting.csv")
+a2 = pd.read_csv("/home/bmanubay/.thermoml/tables/Ken/bincomp_counts_all.csv")
+a3 = pd.read_csv("/home/bmanubay/.thermoml/tables/Ken/bincomp_counts_interesting.csv")
+a4 = pd.read_csv("/home/bmanubay/.thermoml/tables/Ken/mix_counts_all.csv")
+a5 = pd.read_csv("/home/bmanubay/.thermoml/tables/Ken/mix_counts_interesting.csv")
+a6 = pd.read_csv("/home/bmanubay/.thermoml/tables/Ken/purecomp_counts_all.csv")
 b = pd.read_csv("/home/bmanubay/.thermoml/tables/Ken/AlkEthOH_distrib2016may01/AlkEthOH_chain_filt1.smi",delim_whitespace=True,header=None)
 c = pd.read_csv("/home/bmanubay/.thermoml/tables/Ken/AlkEthOH_distrib2016may01/AlkEthOH_rings_filt1.smi",delim_whitespace=True,header=None)
 
 d = pd.merge(b,c,on=0,how='outer')
 d.columns = ["SMILES","chains,","rings"]
 
-ind = a.SMILES.isin(d.SMILES)
+ind0 = a0.SMILES.isin(d.SMILES)
+ind1 = a1.SMILES.isin(d.SMILES)
+ind2 = a2.SMILES.isin(d.SMILES)
+ind3 = a3.SMILES.isin(d.SMILES)
+ind4 = a4.SMILES1.isin(d.SMILES) & a4.SMILES2.isin(d.SMILES) 
+ind5 = a5.SMILES1.isin(d.SMILES) & a5.SMILES2.isin(d.SMILES) 
+ind6 = a6.SMILES.isin(d.SMILES)
 
-a_diverse_chk = a[ind]
+a0_diverse_chk = a0[ind0]
+a0_diverse_chk = a0_diverse_chk.drop("Unnamed: 0", axis = 1)
+a1_diverse_chk = a1[ind1]
+a1_diverse_chk = a1_diverse_chk.drop("Unnamed: 0", axis = 1)
+a2_diverse_chk = a2[ind2]
+a2_diverse_chk = a2_diverse_chk.drop("Unnamed: 0", axis = 1)
+a3_diverse_chk = a3[ind3]
+a3_diverse_chk = a3_diverse_chk.drop("Unnamed: 0", axis = 1)
+a4_diverse_chk = a4[ind4]
+a4_diverse_chk = a4_diverse_chk.drop("Unnamed: 0", axis = 1)
+a5_diverse_chk = a5[ind5]
+a5_diverse_chk = a5_diverse_chk.drop("Unnamed: 0", axis = 1)
+a6_diverse_chk = a6[ind6]
+a6_diverse_chk = a6_diverse_chk.drop("Unnamed: 0", axis = 1)
 
-
-a_diverse_chk.to_csv("/home/bmanubay/.thermoml/tables/Ken/allcomp_counts_diverse.csv") 
+a0_diverse_chk.to_csv("/home/bmanubay/.thermoml/tables/Ken/allcomp_counts_diverse.csv") 
+a1_diverse_chk.to_csv("/home/bmanubay/.thermoml/tables/Ken/allcomp_counts_interesting_diverse.csv")
+a2_diverse_chk.to_csv("/home/bmanubay/.thermoml/tables/Ken/bincomp_counts_diverse.csv")
+a3_diverse_chk.to_csv("/home/bmanubay/.thermoml/tables/Ken/bincomp_counts_interesting_diverse.csv")
+a4_diverse_chk.to_csv("/home/bmanubay/.thermoml/tables/Ken/mix_counts_diverse.csv")
+a5_diverse_chk.to_csv("/home/bmanubay/.thermoml/tables/Ken/mix_counts_intersting_diverse.csv")
+a6_diverse_chk.to_csv("/home/bmanubay/.thermoml/tables/Ken/purecomp_counts_diverse.csv")

--- a/Python/thermomlcnts.py
+++ b/Python/thermomlcnts.py
@@ -18,7 +18,10 @@ mem = Memory(cachedir="/home/bmanubay/.thermoml/")
 def resolve_cached(x, rtype):
    return cirpy.resolve(x, rtype)
 
-# Load in hand filtered property csv corresponding to A set
+# Define list of all alkane SMILES strings that appear in all of our data
+SMILES_alk = ['C', 'CC', 'CCC', 'CCCC', 'CCCCC', 'CCCCCC', 'CCCCCCC', 'CCCCCCCC', 'CCCCCCCCC', 'CCCCCCCCCC', 'CC(C)C', 'CCC(C)C', 'CCCC(C)C', 'C1CCCCC1', 'CC1CCCCC1', 'CCCCCC(C)C', 'CC(C)C(C)C', 'CCC(C)(C)C', 'CCC(C)CC', 'CCCC(C)C', 'CC(C)CC(C)(C)C', 'C1CCCC1', 'C1CCCCCCC1', 'CCC1CCCCC1', 'CC1CCC(C)C(C)C1', 'CCCCC1CCCCC1', 'CC1CCCC1', 'CCCCCCC(C)C', 'CCCCCCCC(C)C', 'CCCCC(C)CCC', 'CCC(C)CCC(C)CC', 'CCC(C)CC(C)CC', 'CCCCCC(C)C', 'C1CCCCCC1', 'CC(C)C(C)C', 'CCC(C)(C)C']
+
+S = pd.DataFrame({'SMILES': SMILES_alk}, columns = ['SMILES'])
 
 ## Pure compounds 
 a1 = pd.read_csv("/home/bmanubay/.thermoml/tables/Ken/Pure/Property data/cpmol_pure.csv")
@@ -155,6 +158,64 @@ count7c = count7c.reset_index()
 count7c.rename(columns={"index":"Component",0:"Count"},inplace=True)
 cc7 = pd.concat([count7c["Component"], count7c["Count"]], axis=1, keys=["Component", "Component Count"])
 
+## Binary Mixtures with alkane-alkane mixtures removed
+cc1c = pd.concat([aa1["x1"], aa1["x2"], aa1['smiles1'], aa1['smiles2']], axis=1, keys = ["x1", "x2", "SMILES1", "SMILES2"]) 
+ind = np.logical_not(cc1c.SMILES1.isin(S.SMILES) & cc1c.SMILES2.isin(S.SMILES))
+cc1c = cc1c[ind]
+cc1c = cc1c.drop(['SMILES1','SMILES2'], axis=1)
+count1c = pd.Series(cc1c.squeeze().values.ravel()).value_counts()
+count1c = count1c.reset_index()
+count1c.rename(columns={"index":"Component",0:"Count"},inplace=True)
+ccc1 = pd.concat([count1c["Component"], count1c["Count"]], axis=1, keys=["Component", "Component Count"])
+cc2c = pd.concat([aa2["x1"], aa2["x2"], aa2['smiles1'], aa2['smiles2']], axis=1, keys = ["x1", "x2", "SMILES1", "SMILES2"]) 
+ind = np.logical_not(cc2c.SMILES1.isin(S.SMILES) & cc2c.SMILES2.isin(S.SMILES))
+cc2c = cc2c[ind]
+cc2c = cc2c.drop(['SMILES1','SMILES2'], axis=1)
+count2c = pd.Series(cc2c.squeeze().values.ravel()).value_counts()
+count2c = count2c.reset_index()
+count2c.rename(columns={"index":"Component",0:"Count"},inplace=True)
+ccc2 = pd.concat([count2c["Component"], count2c["Count"]], axis=1, keys=["Component", "Component Count"])
+cc3c = pd.concat([aa3["x1"], aa3["x2"], aa3['smiles1'], aa3['smiles2']], axis=1, keys = ["x1", "x2", "SMILES1", "SMILES2"]) 
+ind = np.logical_not(cc3c.SMILES1.isin(S.SMILES) & cc3c.SMILES2.isin(S.SMILES))
+cc3c = cc3c[ind]
+cc3c = cc3c.drop(['SMILES1','SMILES2'], axis=1)
+count3c = pd.Series(cc3c.squeeze().values.ravel()).value_counts()
+count3c = count3c.reset_index()
+count3c.rename(columns={"index":"Component",0:"Count"},inplace=True)
+ccc3 = pd.concat([count3c["Component"], count3c["Count"]], axis=1, keys=["Component", "Component Count"])
+cc4c = pd.concat([aa4["x1"], aa4["x2"], aa4['smiles1'], aa4['smiles2']], axis=1, keys = ["x1", "x2", "SMILES1", "SMILES2"]) 
+ind = np.logical_not(cc4c.SMILES1.isin(S.SMILES) & cc4c.SMILES2.isin(S.SMILES))
+cc4c = cc4c[ind]
+cc4c = cc4c.drop(['SMILES1','SMILES2'], axis=1)
+count4c = pd.Series(cc4c.squeeze().values.ravel()).value_counts()
+count4c = count4c.reset_index()
+count4c.rename(columns={"index":"Component",0:"Count"},inplace=True)
+ccc4 = pd.concat([count4c["Component"], count4c["Count"]], axis=1, keys=["Component", "Component Count"])
+cc5c = pd.concat([aa5["x1"], aa5["x2"], aa5['smiles1'], aa5['smiles2']], axis=1, keys = ["x1", "x2", "SMILES1", "SMILES2"])
+ind = np.logical_not(cc5c.SMILES1.isin(S.SMILES) & cc5c.SMILES2.isin(S.SMILES))
+cc5c = cc5c[ind] 
+cc5c = cc5c.drop(['SMILES1','SMILES2'], axis=1)
+count5c = pd.Series(cc5c.squeeze().values.ravel()).value_counts()
+count5c = count5c.reset_index()
+count5c.rename(columns={"index":"Component",0:"Count"},inplace=True)
+ccc5 = pd.concat([count5c["Component"], count5c["Count"]], axis=1, keys=["Component", "Component Count"])
+cc6c = pd.concat([aa6["x1"], aa6["x2"], aa6['smiles1'], aa6['smiles2']], axis=1, keys = ["x1", "x2", "SMILES1", "SMILES2"]) 
+ind = np.logical_not(cc6c.SMILES1.isin(S.SMILES) & cc6c.SMILES2.isin(S.SMILES))
+cc6c = cc6c[ind]
+cc6c = cc6c.drop(['SMILES1','SMILES2'], axis=1)
+count6c = pd.Series(cc6c.squeeze().values.ravel()).value_counts()
+count6c = count6c.reset_index()
+count6c.rename(columns={"index":"Component",0:"Count"},inplace=True)
+ccc6 = pd.concat([count6c["Component"], count6c["Count"]], axis=1, keys=["Component", "Component Count"])
+cc7c = pd.concat([aa7["x1"], aa7["x2"], aa7['smiles1'], aa7['smiles2']], axis=1, keys = ["x1", "x2", "SMILES1", "SMILES2"]) 
+ind = np.logical_not(cc7c.SMILES1.isin(S.SMILES) & cc7c.SMILES2.isin(S.SMILES))
+cc7c = cc7c[ind]
+cc7c = cc7c.drop(['SMILES1','SMILES2'], axis=1)
+count7c = pd.Series(cc7c.squeeze().values.ravel()).value_counts()
+count7c = count7c.reset_index()
+count7c.rename(columns={"index":"Component",0:"Count"},inplace=True)
+ccc7 = pd.concat([count7c["Component"], count7c["Count"]], axis=1, keys=["Component", "Component Count"])
+
 # Get binary mixture counts
 gg1 = aa1["components"].value_counts()
 gg1 = gg1.reset_index()
@@ -236,19 +297,39 @@ b = cc2.merge(cc1,how='outer',on=['Component'],suffixes=(' dens binary', ' actco
 b.replace(np.nan,0,inplace=True)
 b.rename(columns={'Component Count':'Component Count emv binary'},inplace=True)
 
+bb = ccc2.merge(ccc1,how='outer',on=['Component'],suffixes=(' dens binary', ' actcoeff binary')).merge(ccc7,how='outer',on=['Component'],suffixes=(' actcoeff binary', ' sos binary')).merge(ccc3,how='outer',on=['Component'],suffixes=(' sos binary', ' dielec binary')).merge(ccc4,how='outer',on=['Component'],suffixes=(' dielec binary', ' eme binary')).merge(ccc5,how='outer',on=['Component'],suffixes=(' eme binary', ' emcp binary')).merge(ccc6,how='outer',on=['Component'],suffixes=(' emcp binary', ' emv binary'))
+bb.replace(np.nan,0,inplace=True)
+bb.rename(columns={'Component Count':'Component Count emv binary'},inplace=True)
 
 c = pd.merge(a,b,how='outer',on=['Component'])
 c.replace(np.nan,0,inplace=True)
 
+cc = pd.merge(a,bb,how='outer',on=['Component'])
+cc.replace(np.nan,0,inplace=True)
+
 a.insert(1,'SMILES',a.Component.apply(lambda x: resolve_cached(x, "smiles")))
 b.insert(1,'SMILES',b.Component.apply(lambda x: resolve_cached(x, "smiles")))
+bb.insert(1,'SMILES',bb.Component.apply(lambda x: resolve_cached(x, "smiles")))
 c.insert(1,'SMILES',c.Component.apply(lambda x: resolve_cached(x, "smiles")))
+cc.insert(1,'SMILES',cc.Component.apply(lambda x: resolve_cached(x, "smiles")))
 
 d = gg2.merge(gg1,how='outer',on=['Mixture'],suffixes=(' dens binary', ' actcoeff binary')).merge(gg7,how='outer',on=['Mixture'],suffixes=(' actcoeff binary', ' sos binary')).merge(gg3,how='outer',on=['Mixture'],suffixes=(' sos binary', ' dielec binary')).merge(gg4,how='outer',on=['Mixture'],suffixes=(' dielec binary', ' eme binary')).merge(gg5,how='outer',on=['Mixture'],suffixes=(' eme binary', ' emcp binary')).merge(gg6,how='outer',on=['Mixture'],suffixes=(' emcp binary', ' emv binary'))
 d.replace(np.nan,0,inplace=True)
 d.rename(columns={'Mixture Count':'Mixture Count emv binary'},inplace=True)
 
+d["x1"], d["x2"] =  zip(*d["Mixture"].str.split('__').tolist())
+
+d["SMILES1"] = d.x1.apply(lambda x: resolve_cached(x, "smiles"))
+d["SMILES2"] = d.x2.apply(lambda x: resolve_cached(x, "smiles"))
+
+ind = np.logical_not(d.SMILES1.isin(S.SMILES) & d.SMILES2.isin(S.SMILES))
+
+d_int = d[ind]
+
 a.to_csv("/home/bmanubay/.thermoml/tables/Ken/purecomp_counts_all.csv")
 b.to_csv("/home/bmanubay/.thermoml/tables/Ken/bincomp_counts_all.csv")
+bb.to_csv("/home/bmanubay/.thermoml/tables/Ken/bincomp_counts_interesting.csv")
 c.to_csv("/home/bmanubay/.thermoml/tables/Ken/allcomp_counts_all.csv")
+cc.to_csv("/home/bmanubay/.thermoml/tables/Ken/allcomp_counts_interesting.csv")
 d.to_csv("/home/bmanubay/.thermoml/tables/Ken/mix_counts_all.csv")
+d_int.to_csv("/home/bmanubay/.thermoml/tables/Ken/mix_counts_interesting.csv")


### PR DESCRIPTION
I updated the thermomlcnts.py and diversitychk.py scripts (changes appear in 'Python' directory) to apply all possible filter combinations (interesting mixture and Chris's diverse list) to the four main data point count sheets I started with (those with '_all' title appendage).

The changes and new csv appear in the 'Initial Molecule Choices' directory. The README.md file in the 'Initial Molecule Choices' directory has also been simplified and updated for clarity of what is in each csv. 

I'll post an Issue later tonight regarding where (and with what molecules) we should start and ask for input from the rest of the group. 
