### PR TITLE
Switch to using forcefield API to retrieve parameter IDs

### DIFF
--- a/Utilize-All-Parameters/scripts/check_param_coverage.py
+++ b/Utilize-All-Parameters/scripts/check_param_coverage.py
@@ -196,9 +196,9 @@ def find_parameter_ids(filename: str, indices: set) -> \
     return params_by_molecule, param_ids
 
 
-def find_non_covered_params(param_ids):
+def find_non_covered_params(param_ids, ff):
     """Finds the set of parameters in SMIRNOFF not covered by the given set"""
-    smirnoff_ids = utilize_params_util.find_smirnoff_params()
+    smirnoff_ids = utilize_params_util.find_smirnoff_params(ff)
     non_covered = smirnoff_ids - param_ids
     return non_covered
 
@@ -224,7 +224,7 @@ def main():
 
     # Grab molecules and find parameters
     params_by_molecule, param_ids = find_parameter_ids(args["f"], indices)
-    non_covered_params = find_non_covered_params(param_ids)
+    non_covered_params = find_non_covered_params(param_ids, FORCEFIELD)
 
     # Save data
     save_data_to_json(args["d"], params_by_molecule, param_ids)

--- a/Utilize-All-Parameters/scripts/utilize_params_util.py
+++ b/Utilize-All-Parameters/scripts/utilize_params_util.py
@@ -1,21 +1,15 @@
 # Utility functions for use in all scripts here
 
 
-def find_smirnoff_params() -> set:
-    """Creates a set of all the smirnoff params"""
+def find_smirnoff_params(ff) -> set:
+    """Creates a set of all the smirnoff params, given a forcefield object. Loops over Bonds, Angles, ProperTorsions, ImproperTorsions, vdW only."""
     smirnoff_ids = set()
 
-    # number of parameters of each type
-    num_params = {
-        'b': 87,
-        'a': 38,
-        't': 158,
-        'n': 35,
-        'i': 4,
-    }
-    for (param_type, param_count) in num_params.items():
-        for i in range(1, param_count + 1):
-            smirnoff_ids.add(f"{param_type}{i}")
+    handlers = ["Bonds", "Angles", "ProperTorsions", "ImproperTorsions", "vdW"]
+    for handler in handlers:
+        phandler = ff.get_parameter_handler(handler)
+        for p in phandler.parameters:
+            smirnoff_ids.add(p.id)
 
     return smirnoff_ids
 


### PR DESCRIPTION
Originally, the code to check utilization of parameters assumed all parameter IDs were sequential and following a simple pattern. This generalizes by using the forcefield API to retrieve parameter usage details.